### PR TITLE
FLOW-2102 Add basic support for ContentObject comparisons

### DIFF
--- a/__tests__/services/rules.test.ts
+++ b/__tests__/services/rules.test.ts
@@ -524,9 +524,25 @@ describe('Rules service Content Object expected behaviour', () => {
         expect(Rules.compareValues({ objectData: [] }, null, manywho.component.contentTypes.object, 'BAD_CRITERIA')).toBeFalsy();
     });
 
+    test('EQUAL criteria for a Content Object', () => {
+        expect(Rules.compareValues({ objectData: [] }, { objectData: [] }, manywho.component.contentTypes.object, 'EQUAL')).toBeTruthy();
+        expect(Rules.compareValues({ objectData: [] }, { objectData: [1] }, manywho.component.contentTypes.object, 'EQUAL')).toBeFalsy();
+        expect(Rules.compareValues({ contentValue: 'a', objectData: null },
+                                   { contentValue: 'a', objectData: null }, manywho.component.contentTypes.object, 'EQUAL')).toBeTruthy();
+        expect(Rules.compareValues({ contentValue: 'a', objectData: null },
+                                   { contentValue: 'b', objectData: null }, manywho.component.contentTypes.object, 'EQUAL')).toBeFalsy();
+    });
+
+    test('NOT_EQUAL criteria for a Content Object', () => {
+        expect(Rules.compareValues({ objectData: [] }, { objectData: [] }, manywho.component.contentTypes.object, 'NOT_EQUAL')).toBeFalsy();
+        expect(Rules.compareValues({ objectData: [] }, { objectData: [1] }, manywho.component.contentTypes.object, 'NOT_EQUAL')).toBeTruthy();
+        expect(Rules.compareValues({ contentValue: 'a', objectData: null },
+                                   { contentValue: 'a', objectData: null }, manywho.component.contentTypes.object, 'NOT_EQUAL')).toBeFalsy();
+        expect(Rules.compareValues({ contentValue: 'a', objectData: null },
+                                   { contentValue: 'b', objectData: null }, manywho.component.contentTypes.object, 'NOT_EQUAL')).toBeTruthy();
+    });
+
     test('Unsupported criteria for a Content Object', () => {
-        expect(Rules.compareValues({ objectData: [] }, { objectData: [] }, manywho.component.contentTypes.object, 'EQUAL')).toBeFalsy();
-        expect(Rules.compareValues({ objectData: [] }, { objectData: [1] }, manywho.component.contentTypes.object, 'NOT_EQUAL')).toBeFalsy();
         expect(Rules.compareValues({ objectData: [] }, { objectData: [1] }, manywho.component.contentTypes.object, 'GREATER_THAN')).toBeFalsy();
         expect(Rules.compareValues({ objectData: [] }, { objectData: [1] }, manywho.component.contentTypes.object, 'GREATER_THAN_OR_EQUAL'))
             .toBeFalsy();

--- a/js/services/Operation.ts
+++ b/js/services/Operation.ts
@@ -99,8 +99,13 @@ export const executeOperation = (operation: any, state: IState, snapshot: any) =
                 } else if (manywho.utils.isEqual(operation.valueElementToReferenceId.command, 'GET_NEXT', true)) {
                     const v = clone(valueToReference);
                     const idx = v.index ? v.index : 0;
-                    valueToReference.objectData = idx < v.objectData.length ? [v.objectData[idx]] : [];
-                    v.index = idx + 1;
+                    if (idx < v.objectData.length) {
+                        valueToReference.objectData = [v.objectData[idx]];
+                        v.index = idx + 1;
+                    } else {
+                        valueToReference.objectData = [];
+                        v.index = 0; // Reset pointer
+                    }
                     setStateValue(operation.valueElementToReferenceId, valueToReference.typeElementId, snapshot, v);
                 }
             }

--- a/js/services/Rules.ts
+++ b/js/services/Rules.ts
@@ -109,7 +109,7 @@ const Rules = {
     compareValues(left: any, right: any, contentType: any, criteriaType: string) {
         switch (contentType) {
         case manywho.component.contentTypes.object:
-            return Rules.compareObjects(criteriaType, left);
+            return Rules.compareObjects(criteriaType, left, right);
         case manywho.component.contentTypes.list:
             return Rules.compareLists(criteriaType, left);
         default:
@@ -140,6 +140,10 @@ const Rules = {
             return contentValue ? moment(contentValue) : contentValue;
         case manywho.component.contentTypes.boolean:
             return contentValue ? Boolean(contentValue) : contentValue;
+        case manywho.component.contentTypes.object:
+            // If the Value has no objectdata then return the content because some Values
+            // from getState() are just single property stored in the contentValue member.
+            return value.objectData && value.objectData.length > 0 ? value : contentValue || '';
         default:
             // TODO - Exception ?
             return contentValue;
@@ -202,12 +206,19 @@ const Rules = {
      * TODO: Un-hide the docs for this onces its implemented
      * @hidden
      * @param criteriaType
-     * @param value
+     * @param left
+     * @param right
      */
-    compareObjects(criteriaType: string, value: any) {
+    compareObjects(criteriaType: string, left: any, right: any) {
         switch (criteriaType.toUpperCase()) {
         case 'IS_EMPTY':
-            return !(value && value.objectData && value.objectData.length > 0);
+            return !(left && left.objectData && left.objectData.length > 0);
+        case 'EQUAL':
+            return Rules.getContentValue(left, manywho.component.contentTypes.object) ===
+                Rules.getContentValue(right, manywho.component.contentTypes.object);
+        case 'NOT_EQUAL':
+            return Rules.getContentValue(left, manywho.component.contentTypes.object) !==
+                Rules.getContentValue(right, manywho.component.contentTypes.object);
         }
     },
 


### PR DESCRIPTION
The issues raised in the Confluence tests are now fixed by adding basic support for ContentObject comparisons.