### PR TITLE
FLOW-1619 - Updated version of clean webpack plugin causing dist buil…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
             "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "requires": {
-                "@babel/highlight": "7.10.4"
+                "@babel/highlight": "^7.10.4"
             }
         },
         "@babel/core": {
@@ -17,22 +17,22 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
             "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
             "requires": {
-                "@babel/code-frame": "7.10.4",
-                "@babel/generator": "7.10.4",
-                "@babel/helper-module-transforms": "7.10.4",
-                "@babel/helpers": "7.10.4",
-                "@babel/parser": "7.10.4",
-                "@babel/template": "7.10.4",
-                "@babel/traverse": "7.10.4",
-                "@babel/types": "7.10.4",
-                "convert-source-map": "1.7.0",
-                "debug": "4.1.1",
-                "gensync": "1.0.0-beta.1",
-                "json5": "2.1.3",
-                "lodash": "4.17.15",
-                "resolve": "1.17.0",
-                "semver": "5.7.1",
-                "source-map": "0.5.7"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helpers": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.2",
+                "lodash": "^4.17.13",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
             },
             "dependencies": {
                 "json5": {
@@ -40,7 +40,7 @@
                     "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
                     "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "requires": {
-                        "minimist": "1.2.5"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "source-map": {
@@ -55,10 +55,10 @@
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
             "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
             "requires": {
-                "@babel/types": "7.10.4",
-                "jsesc": "2.5.2",
-                "lodash": "4.17.15",
-                "source-map": "0.5.7"
+                "@babel/types": "^7.10.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.13",
+                "source-map": "^0.5.0"
             },
             "dependencies": {
                 "source-map": {
@@ -73,7 +73,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
             "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -81,8 +81,8 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
             "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-builder-react-jsx-experimental": {
@@ -90,9 +90,9 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.4.tgz",
             "integrity": "sha512-LyacH/kgQPgLAuaWrvvq1+E7f5bLyT8jXCh7nM67sRsy2cpIGfgWJ+FCnAKQXfY+F0tXUaN6FqLkp4JiCzdK8Q==",
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.10.4",
-                "@babel/helper-module-imports": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-function-name": {
@@ -100,9 +100,9 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
             "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
             "requires": {
-                "@babel/helper-get-function-arity": "7.10.4",
-                "@babel/template": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -110,7 +110,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
             "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -118,7 +118,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
             "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-module-imports": {
@@ -126,7 +126,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
             "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-module-transforms": {
@@ -134,13 +134,13 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
             "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
             "requires": {
-                "@babel/helper-module-imports": "7.10.4",
-                "@babel/helper-replace-supers": "7.10.4",
-                "@babel/helper-simple-access": "7.10.4",
-                "@babel/helper-split-export-declaration": "7.10.4",
-                "@babel/template": "7.10.4",
-                "@babel/types": "7.10.4",
-                "lodash": "4.17.15"
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4",
+                "lodash": "^4.17.13"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -148,7 +148,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
             "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -161,10 +161,10 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
             "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
             "requires": {
-                "@babel/helper-member-expression-to-functions": "7.10.4",
-                "@babel/helper-optimise-call-expression": "7.10.4",
-                "@babel/traverse": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-simple-access": {
@@ -172,8 +172,8 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
             "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
             "requires": {
-                "@babel/template": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -181,7 +181,7 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
             "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -194,9 +194,9 @@
             "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
             "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
             "requires": {
-                "@babel/template": "7.10.4",
-                "@babel/traverse": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/highlight": {
@@ -204,9 +204,9 @@
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
             "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "requires": {
-                "@babel/helper-validator-identifier": "7.10.4",
-                "chalk": "2.4.2",
-                "js-tokens": "4.0.0"
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
@@ -220,7 +220,7 @@
             "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-bigint": {
@@ -229,7 +229,7 @@
             "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-class-properties": {
@@ -238,7 +238,7 @@
             "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-import-meta": {
@@ -247,7 +247,7 @@
             "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-json-strings": {
@@ -256,7 +256,7 @@
             "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-jsx": {
@@ -264,7 +264,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
             "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-logical-assignment-operators": {
@@ -273,7 +273,7 @@
             "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -282,7 +282,7 @@
             "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-numeric-separator": {
@@ -291,7 +291,7 @@
             "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-syntax-object-rest-spread": {
@@ -300,7 +300,7 @@
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-optional-catch-binding": {
@@ -309,7 +309,7 @@
             "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-syntax-optional-chaining": {
@@ -318,7 +318,7 @@
             "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.8.0"
             }
         },
         "@babel/plugin-transform-react-display-name": {
@@ -326,7 +326,7 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz",
             "integrity": "sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==",
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx": {
@@ -334,10 +334,10 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
             "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
             "requires": {
-                "@babel/helper-builder-react-jsx": "7.10.4",
-                "@babel/helper-builder-react-jsx-experimental": "7.10.4",
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@babel/plugin-syntax-jsx": "7.10.4"
+                "@babel/helper-builder-react-jsx": "^7.10.4",
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-development": {
@@ -345,9 +345,9 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz",
             "integrity": "sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==",
             "requires": {
-                "@babel/helper-builder-react-jsx-experimental": "7.10.4",
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@babel/plugin-syntax-jsx": "7.10.4"
+                "@babel/helper-builder-react-jsx-experimental": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-self": {
@@ -355,8 +355,8 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz",
             "integrity": "sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==",
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@babel/plugin-syntax-jsx": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
@@ -364,8 +364,8 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.4.tgz",
             "integrity": "sha512-FTK3eQFrPv2aveerUSazFmGygqIdTtvskG50SnGnbEUnRPcGx2ylBhdFIzoVS1ty44hEgcPoCAyw5r3VDEq+Ug==",
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@babel/plugin-syntax-jsx": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-jsx": "^7.10.4"
             }
         },
         "@babel/plugin-transform-react-pure-annotations": {
@@ -373,8 +373,8 @@
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz",
             "integrity": "sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==",
             "requires": {
-                "@babel/helper-annotate-as-pure": "7.10.4",
-                "@babel/helper-plugin-utils": "7.10.4"
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
             }
         },
         "@babel/preset-react": {
@@ -382,13 +382,13 @@
             "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.10.4.tgz",
             "integrity": "sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==",
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@babel/plugin-transform-react-display-name": "7.10.4",
-                "@babel/plugin-transform-react-jsx": "7.10.4",
-                "@babel/plugin-transform-react-jsx-development": "7.10.4",
-                "@babel/plugin-transform-react-jsx-self": "7.10.4",
-                "@babel/plugin-transform-react-jsx-source": "7.10.4",
-                "@babel/plugin-transform-react-pure-annotations": "7.10.4"
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-react-display-name": "^7.10.4",
+                "@babel/plugin-transform-react-jsx": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-development": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-self": "^7.10.4",
+                "@babel/plugin-transform-react-jsx-source": "^7.10.4",
+                "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
             }
         },
         "@babel/runtime": {
@@ -396,7 +396,7 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.4.tgz",
             "integrity": "sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==",
             "requires": {
-                "regenerator-runtime": "0.13.5"
+                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/runtime-corejs3": {
@@ -405,8 +405,8 @@
             "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
             "dev": true,
             "requires": {
-                "core-js-pure": "3.6.5",
-                "regenerator-runtime": "0.13.5"
+                "core-js-pure": "^3.0.0",
+                "regenerator-runtime": "^0.13.4"
             }
         },
         "@babel/template": {
@@ -414,9 +414,9 @@
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
             "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
             "requires": {
-                "@babel/code-frame": "7.10.4",
-                "@babel/parser": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
             }
         },
         "@babel/traverse": {
@@ -424,15 +424,15 @@
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
             "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
             "requires": {
-                "@babel/code-frame": "7.10.4",
-                "@babel/generator": "7.10.4",
-                "@babel/helper-function-name": "7.10.4",
-                "@babel/helper-split-export-declaration": "7.10.4",
-                "@babel/parser": "7.10.4",
-                "@babel/types": "7.10.4",
-                "debug": "4.1.1",
-                "globals": "11.12.0",
-                "lodash": "4.17.15"
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.4",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.13"
             }
         },
         "@babel/types": {
@@ -440,9 +440,9 @@
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
             "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
             "requires": {
-                "@babel/helper-validator-identifier": "7.10.4",
-                "lodash": "4.17.15",
-                "to-fast-properties": "2.0.0"
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.13",
+                "to-fast-properties": "^2.0.0"
             }
         },
         "@bcoe/v8-coverage": {
@@ -457,8 +457,8 @@
             "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
             "dev": true,
             "requires": {
-                "exec-sh": "0.3.4",
-                "minimist": "1.2.5"
+                "exec-sh": "^0.3.2",
+                "minimist": "^1.2.0"
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -467,11 +467,11 @@
             "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "dev": true,
             "requires": {
-                "camelcase": "5.3.1",
-                "find-up": "4.1.0",
-                "get-package-type": "0.1.0",
-                "js-yaml": "3.14.0",
-                "resolve-from": "5.0.0"
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -480,8 +480,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "locate-path": {
@@ -490,7 +490,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -499,7 +499,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -528,11 +528,11 @@
             "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-util": "26.1.0",
-                "slash": "3.0.0"
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "jest-message-util": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -541,10 +541,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -553,8 +553,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -563,8 +563,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -573,7 +573,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -594,7 +594,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -605,33 +605,33 @@
             "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
             "dev": true,
             "requires": {
-                "@jest/console": "26.1.0",
-                "@jest/reporters": "26.1.0",
-                "@jest/test-result": "26.1.0",
-                "@jest/transform": "26.1.0",
-                "@jest/types": "26.1.0",
-                "ansi-escapes": "4.3.1",
-                "chalk": "4.1.0",
-                "exit": "0.1.2",
-                "graceful-fs": "4.2.4",
-                "jest-changed-files": "26.1.0",
-                "jest-config": "26.1.0",
-                "jest-haste-map": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-regex-util": "26.0.0",
-                "jest-resolve": "26.1.0",
-                "jest-resolve-dependencies": "26.1.0",
-                "jest-runner": "26.1.0",
-                "jest-runtime": "26.1.0",
-                "jest-snapshot": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-validate": "26.1.0",
-                "jest-watcher": "26.1.0",
-                "micromatch": "4.0.2",
-                "p-each-series": "2.1.0",
-                "rimraf": "3.0.2",
-                "slash": "3.0.0",
-                "strip-ansi": "6.0.0"
+                "@jest/console": "^26.1.0",
+                "@jest/reporters": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/transform": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-changed-files": "^26.1.0",
+                "jest-config": "^26.1.0",
+                "jest-haste-map": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.1.0",
+                "jest-resolve-dependencies": "^26.1.0",
+                "jest-runner": "^26.1.0",
+                "jest-runtime": "^26.1.0",
+                "jest-snapshot": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-validate": "^26.1.0",
+                "jest-watcher": "^26.1.0",
+                "micromatch": "^4.0.2",
+                "p-each-series": "^2.1.0",
+                "rimraf": "^3.0.0",
+                "slash": "^3.0.0",
+                "strip-ansi": "^6.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -640,10 +640,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -652,8 +652,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -662,8 +662,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -672,7 +672,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -693,7 +693,7 @@
                     "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.6"
+                        "glob": "^7.1.3"
                     }
                 },
                 "supports-color": {
@@ -702,7 +702,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -713,9 +713,9 @@
             "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "26.1.0",
-                "@jest/types": "26.1.0",
-                "jest-mock": "26.1.0"
+                "@jest/fake-timers": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "jest-mock": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -724,10 +724,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -736,8 +736,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -746,8 +746,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -756,7 +756,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -777,7 +777,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -788,11 +788,11 @@
             "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "@sinonjs/fake-timers": "6.0.1",
-                "jest-message-util": "26.1.0",
-                "jest-mock": "26.1.0",
-                "jest-util": "26.1.0"
+                "@jest/types": "^26.1.0",
+                "@sinonjs/fake-timers": "^6.0.1",
+                "jest-message-util": "^26.1.0",
+                "jest-mock": "^26.1.0",
+                "jest-util": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -801,10 +801,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -813,8 +813,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -823,8 +823,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -833,7 +833,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -854,7 +854,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -865,9 +865,9 @@
             "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "26.1.0",
-                "@jest/types": "26.1.0",
-                "expect": "26.1.0"
+                "@jest/environment": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "expect": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -876,10 +876,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -888,8 +888,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -898,8 +898,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -908,7 +908,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -929,7 +929,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -940,31 +940,31 @@
             "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
             "dev": true,
             "requires": {
-                "@bcoe/v8-coverage": "0.2.3",
-                "@jest/console": "26.1.0",
-                "@jest/test-result": "26.1.0",
-                "@jest/transform": "26.1.0",
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "collect-v8-coverage": "1.0.1",
-                "exit": "0.1.2",
-                "glob": "7.1.6",
-                "graceful-fs": "4.2.4",
-                "istanbul-lib-coverage": "3.0.0",
-                "istanbul-lib-instrument": "4.0.3",
-                "istanbul-lib-report": "3.0.0",
-                "istanbul-lib-source-maps": "4.0.0",
-                "istanbul-reports": "3.0.2",
-                "jest-haste-map": "26.1.0",
-                "jest-resolve": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-worker": "26.1.0",
-                "node-notifier": "7.0.1",
-                "slash": "3.0.0",
-                "source-map": "0.6.1",
-                "string-length": "4.0.1",
-                "terminal-link": "2.1.1",
-                "v8-to-istanbul": "4.1.4"
+                "@bcoe/v8-coverage": "^0.2.3",
+                "@jest/console": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/transform": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.2.4",
+                "istanbul-lib-coverage": "^3.0.0",
+                "istanbul-lib-instrument": "^4.0.3",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.0",
+                "istanbul-reports": "^3.0.2",
+                "jest-haste-map": "^26.1.0",
+                "jest-resolve": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-worker": "^26.1.0",
+                "node-notifier": "^7.0.0",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.0",
+                "string-length": "^4.0.1",
+                "terminal-link": "^2.0.0",
+                "v8-to-istanbul": "^4.1.3"
             },
             "dependencies": {
                 "@jest/types": {
@@ -973,10 +973,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -985,8 +985,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -995,8 +995,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -1005,7 +1005,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -1026,7 +1026,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1037,9 +1037,9 @@
             "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
             "dev": true,
             "requires": {
-                "callsites": "3.1.0",
-                "graceful-fs": "4.2.4",
-                "source-map": "0.6.1"
+                "callsites": "^3.0.0",
+                "graceful-fs": "^4.2.4",
+                "source-map": "^0.6.0"
             }
         },
         "@jest/test-result": {
@@ -1048,10 +1048,10 @@
             "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
             "dev": true,
             "requires": {
-                "@jest/console": "26.1.0",
-                "@jest/types": "26.1.0",
-                "@types/istanbul-lib-coverage": "2.0.3",
-                "collect-v8-coverage": "1.0.1"
+                "@jest/console": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "collect-v8-coverage": "^1.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -1060,10 +1060,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -1072,8 +1072,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -1082,8 +1082,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -1092,7 +1092,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -1113,7 +1113,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1124,11 +1124,11 @@
             "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "26.1.0",
-                "graceful-fs": "4.2.4",
-                "jest-haste-map": "26.1.0",
-                "jest-runner": "26.1.0",
-                "jest-runtime": "26.1.0"
+                "@jest/test-result": "^26.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.1.0",
+                "jest-runner": "^26.1.0",
+                "jest-runtime": "^26.1.0"
             }
         },
         "@jest/transform": {
@@ -1137,21 +1137,21 @@
             "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
             "dev": true,
             "requires": {
-                "@babel/core": "7.10.4",
-                "@jest/types": "26.1.0",
-                "babel-plugin-istanbul": "6.0.0",
-                "chalk": "4.1.0",
-                "convert-source-map": "1.7.0",
-                "fast-json-stable-stringify": "2.1.0",
-                "graceful-fs": "4.2.4",
-                "jest-haste-map": "26.1.0",
-                "jest-regex-util": "26.0.0",
-                "jest-util": "26.1.0",
-                "micromatch": "4.0.2",
-                "pirates": "4.0.1",
-                "slash": "3.0.0",
-                "source-map": "0.6.1",
-                "write-file-atomic": "3.0.3"
+                "@babel/core": "^7.1.0",
+                "@jest/types": "^26.1.0",
+                "babel-plugin-istanbul": "^6.0.0",
+                "chalk": "^4.0.0",
+                "convert-source-map": "^1.4.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-haste-map": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-util": "^26.1.0",
+                "micromatch": "^4.0.2",
+                "pirates": "^4.0.1",
+                "slash": "^3.0.0",
+                "source-map": "^0.6.1",
+                "write-file-atomic": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -1160,10 +1160,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -1172,8 +1172,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -1182,8 +1182,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -1192,7 +1192,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -1213,7 +1213,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1224,10 +1224,10 @@
             "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "2.0.3",
-                "@types/istanbul-reports": "1.1.2",
-                "@types/yargs": "15.0.5",
-                "chalk": "3.0.0"
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^1.1.1",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^3.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1236,8 +1236,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -1246,8 +1246,8 @@
                     "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -1256,7 +1256,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -1277,7 +1277,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -1297,7 +1297,7 @@
             "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
             "dev": true,
             "requires": {
-                "@sinonjs/commons": "1.8.0"
+                "@sinonjs/commons": "^1.7.0"
             }
         },
         "@types/anymatch": {
@@ -1311,11 +1311,11 @@
             "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
             "dev": true,
             "requires": {
-                "@babel/parser": "7.10.4",
-                "@babel/types": "7.10.4",
-                "@types/babel__generator": "7.6.1",
-                "@types/babel__template": "7.0.2",
-                "@types/babel__traverse": "7.0.12"
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "@types/babel__generator": "*",
+                "@types/babel__template": "*",
+                "@types/babel__traverse": "*"
             }
         },
         "@types/babel__generator": {
@@ -1324,7 +1324,7 @@
             "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.0.0"
             }
         },
         "@types/babel__template": {
@@ -1333,8 +1333,8 @@
             "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
             "dev": true,
             "requires": {
-                "@babel/parser": "7.10.4",
-                "@babel/types": "7.10.4"
+                "@babel/parser": "^7.1.0",
+                "@babel/types": "^7.0.0"
             }
         },
         "@types/babel__traverse": {
@@ -1343,7 +1343,7 @@
             "integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.10.4"
+                "@babel/types": "^7.3.0"
             }
         },
         "@types/bluebird": {
@@ -1364,7 +1364,7 @@
             "integrity": "sha512-Fq7R3fINAPSdUEhOyjG4iVxgHrOnqDJbY0/BUuiN0pvD/rfmZWekVZnv+vcs8TtpA2XF50uv50LaE4EnpEL/Hw==",
             "dev": true,
             "requires": {
-                "@types/node": "14.0.14"
+                "@types/node": "*"
             }
         },
         "@types/color-name": {
@@ -1378,8 +1378,8 @@
             "integrity": "sha512-R+phe509UuUYy9Tk0YlSbipRpfVtIzb/9BHn5pTEtjJTF5LXvUjrIQcZvNyANNEyFrd2YGs196PniNT1fgvOQA==",
             "dev": true,
             "requires": {
-                "@types/cheerio": "0.22.18",
-                "@types/react": "16.9.41"
+                "@types/cheerio": "*",
+                "@types/react": "*"
             }
         },
         "@types/enzyme-adapter-react-16": {
@@ -1388,7 +1388,7 @@
             "integrity": "sha512-VonDkZ15jzqDWL8mPFIQnnLtjwebuL9YnDkqeCDYnB4IVgwUm0mwKkqhrxLL6mb05xm7qqa3IE95m8CZE9imCg==",
             "dev": true,
             "requires": {
-                "@types/enzyme": "3.10.5"
+                "@types/enzyme": "*"
             }
         },
         "@types/eslint-visitor-keys": {
@@ -1402,8 +1402,8 @@
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
             "requires": {
-                "@types/minimatch": "3.0.3",
-                "@types/node": "14.0.14"
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/graceful-fs": {
@@ -1412,7 +1412,7 @@
             "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
             "dev": true,
             "requires": {
-                "@types/node": "14.0.14"
+                "@types/node": "*"
             }
         },
         "@types/hoist-non-react-statics": {
@@ -1421,8 +1421,8 @@
             "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
             "dev": true,
             "requires": {
-                "@types/react": "16.9.41",
-                "hoist-non-react-statics": "3.3.2"
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0"
             }
         },
         "@types/istanbul-lib-coverage": {
@@ -1437,7 +1437,7 @@
             "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "2.0.3"
+                "@types/istanbul-lib-coverage": "*"
             }
         },
         "@types/istanbul-reports": {
@@ -1446,8 +1446,8 @@
             "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "2.0.3",
-                "@types/istanbul-lib-report": "3.0.0"
+                "@types/istanbul-lib-coverage": "*",
+                "@types/istanbul-lib-report": "*"
             }
         },
         "@types/jest": {
@@ -1456,8 +1456,8 @@
             "integrity": "sha512-v89ga1clpVL/Y1+YI0eIu1VMW+KU7Xl8PhylVtDKVWaSUHBHYPLXMQGBdrpHewaKoTvlXkksbYqPgz8b4cmRZg==",
             "dev": true,
             "requires": {
-                "jest-diff": "25.5.0",
-                "pretty-format": "25.5.0"
+                "jest-diff": "^25.2.1",
+                "pretty-format": "^25.2.1"
             }
         },
         "@types/json-schema": {
@@ -1517,8 +1517,8 @@
             "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
             "dev": true,
             "requires": {
-                "@types/prop-types": "15.7.3",
-                "csstype": "2.6.11"
+                "@types/prop-types": "*",
+                "csstype": "^2.2.0"
             }
         },
         "@types/react-dom": {
@@ -1527,7 +1527,7 @@
             "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
             "dev": true,
             "requires": {
-                "@types/react": "16.9.41"
+                "@types/react": "*"
             }
         },
         "@types/react-redux": {
@@ -1536,10 +1536,10 @@
             "integrity": "sha512-mpC0jqxhP4mhmOl3P4ipRsgTgbNofMRXJb08Ms6gekViLj61v1hOZEKWDCyWsdONr6EjEA6ZHXC446wdywDe0w==",
             "dev": true,
             "requires": {
-                "@types/hoist-non-react-statics": "3.3.1",
-                "@types/react": "16.9.41",
-                "hoist-non-react-statics": "3.3.2",
-                "redux": "4.0.5"
+                "@types/hoist-non-react-statics": "^3.3.0",
+                "@types/react": "*",
+                "hoist-non-react-statics": "^3.3.0",
+                "redux": "^4.0.0"
             }
         },
         "@types/redux": {
@@ -1554,10 +1554,10 @@
             "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
             "dev": true,
             "requires": {
-                "@types/caseless": "0.12.2",
-                "@types/node": "14.0.14",
-                "@types/tough-cookie": "4.0.0",
-                "form-data": "2.5.1"
+                "@types/caseless": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "form-data": "^2.5.0"
             }
         },
         "@types/request-promise": {
@@ -1566,8 +1566,8 @@
             "integrity": "sha512-3Thpj2Va5m0ji3spaCk8YKrjkZyZc6RqUVOphA0n/Xet66AW/AiOAs5vfXhQIL5NmkaO7Jnun7Nl9NEjJ2zBaw==",
             "dev": true,
             "requires": {
-                "@types/bluebird": "3.5.32",
-                "@types/request": "2.48.5"
+                "@types/bluebird": "*",
+                "@types/request": "*"
             }
         },
         "@types/source-list-map": {
@@ -1597,7 +1597,7 @@
             "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.2.tgz",
             "integrity": "sha512-d6dIfpPbF+8B7WiCi2ELY7m0w1joD8cRW4ms88Emdb2w062NeEpbNCeWwVCgzLRpVG+5e74VFSg4rgJ2xXjEiQ==",
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.1"
             }
         },
         "@types/uglifyjs-webpack-plugin": {
@@ -1606,7 +1606,7 @@
             "integrity": "sha512-QoCJYq+zNtuvKw4nutaIxQXKBpvc0Hd6U7BUVi2Cest2FrkGTYDBD6YpSq5d9IHjo94SjXk+6KDqQVOcEzFJZA==",
             "dev": true,
             "requires": {
-                "@types/webpack": "4.41.18"
+                "@types/webpack": "*"
             }
         },
         "@types/webpack": {
@@ -1614,12 +1614,12 @@
             "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.18.tgz",
             "integrity": "sha512-mQm2R8vV2BZE/qIDVYqmBVLfX73a8muwjs74SpjEyJWJxeXBbsI9L65Pcia9XfYLYWzD1c1V8m+L0p30y2N7MA==",
             "requires": {
-                "@types/anymatch": "1.3.1",
-                "@types/node": "14.0.14",
-                "@types/tapable": "1.0.6",
-                "@types/uglify-js": "3.9.2",
-                "@types/webpack-sources": "1.4.0",
-                "source-map": "0.6.1"
+                "@types/anymatch": "*",
+                "@types/node": "*",
+                "@types/tapable": "*",
+                "@types/uglify-js": "*",
+                "@types/webpack-sources": "*",
+                "source-map": "^0.6.0"
             }
         },
         "@types/webpack-sources": {
@@ -1627,9 +1627,9 @@
             "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.0.tgz",
             "integrity": "sha512-c88dKrpSle9BtTqR6ifdaxu1Lvjsl3C5OsfvuUbUwdXymshv1TkufUAXBajCCUM/f/TmnkZC/Esb03MinzSiXQ==",
             "requires": {
-                "@types/node": "14.0.14",
-                "@types/source-list-map": "0.1.2",
-                "source-map": "0.7.3"
+                "@types/node": "*",
+                "@types/source-list-map": "*",
+                "source-map": "^0.7.3"
             },
             "dependencies": {
                 "source-map": {
@@ -1645,7 +1645,7 @@
             "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
             "dev": true,
             "requires": {
-                "@types/yargs-parser": "15.0.0"
+                "@types/yargs-parser": "*"
             }
         },
         "@types/yargs-parser": {
@@ -1661,11 +1661,11 @@
             "dev": true,
             "requires": {
                 "@typescript-eslint/experimental-utils": "3.5.0",
-                "debug": "4.1.1",
-                "functional-red-black-tree": "1.0.1",
-                "regexpp": "3.1.0",
-                "semver": "7.3.2",
-                "tsutils": "3.17.1"
+                "debug": "^4.1.1",
+                "functional-red-black-tree": "^1.0.1",
+                "regexpp": "^3.0.0",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
             },
             "dependencies": {
                 "semver": {
@@ -1682,11 +1682,11 @@
             "integrity": "sha512-zGNOrVi5Wz0jcjUnFZ6QUD0MCox5hBuVwemGCew2qJzUX5xPoyR+0EzS5qD5qQXL/vnQ8Eu+nv03tpeFRwLrDg==",
             "dev": true,
             "requires": {
-                "@types/json-schema": "7.0.5",
+                "@types/json-schema": "^7.0.3",
                 "@typescript-eslint/types": "3.5.0",
                 "@typescript-eslint/typescript-estree": "3.5.0",
-                "eslint-scope": "5.1.0",
-                "eslint-utils": "2.1.0"
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
             }
         },
         "@typescript-eslint/parser": {
@@ -1695,11 +1695,11 @@
             "integrity": "sha512-sU07VbYB70WZHtgOjH/qfAp1+OwaWgrvD1Km1VXqRpcVxt971PMTU7gJtlrCje0M+Sdz7xKAbtiyIu+Y6QdnVA==",
             "dev": true,
             "requires": {
-                "@types/eslint-visitor-keys": "1.0.0",
+                "@types/eslint-visitor-keys": "^1.0.0",
                 "@typescript-eslint/experimental-utils": "3.5.0",
                 "@typescript-eslint/types": "3.5.0",
                 "@typescript-eslint/typescript-estree": "3.5.0",
-                "eslint-visitor-keys": "1.3.0"
+                "eslint-visitor-keys": "^1.1.0"
             }
         },
         "@typescript-eslint/types": {
@@ -1716,12 +1716,12 @@
             "requires": {
                 "@typescript-eslint/types": "3.5.0",
                 "@typescript-eslint/visitor-keys": "3.5.0",
-                "debug": "4.1.1",
-                "glob": "7.1.6",
-                "is-glob": "4.0.1",
-                "lodash": "4.17.15",
-                "semver": "7.3.2",
-                "tsutils": "3.17.1"
+                "debug": "^4.1.1",
+                "glob": "^7.1.6",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
             },
             "dependencies": {
                 "semver": {
@@ -1738,7 +1738,7 @@
             "integrity": "sha512-7cTp9rcX2sz9Z+zua9MCOX4cqp5rYyFD5o8LlbSpXrMTXoRdngTtotRZEkm8+FNMHPWYFhitFK+qt/brK8BVJQ==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "1.3.0"
+                "eslint-visitor-keys": "^1.1.0"
             }
         },
         "@webassemblyjs/ast": {
@@ -1818,7 +1818,7 @@
             "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
             "dev": true,
             "requires": {
-                "@xtuc/ieee754": "1.2.0"
+                "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1939,7 +1939,7 @@
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
             "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
             "requires": {
-                "mime-types": "2.1.27",
+                "mime-types": "~2.1.24",
                 "negotiator": "0.6.2"
             }
         },
@@ -1954,8 +1954,8 @@
             "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
             "dev": true,
             "requires": {
-                "acorn": "7.3.1",
-                "acorn-walk": "7.2.0"
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1"
             }
         },
         "acorn-jsx": {
@@ -1975,8 +1975,8 @@
             "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
             "dev": true,
             "requires": {
-                "clean-stack": "2.2.0",
-                "indent-string": "4.0.0"
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
             }
         },
         "airbnb-prop-types": {
@@ -1985,15 +1985,15 @@
             "integrity": "sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==",
             "dev": true,
             "requires": {
-                "array.prototype.find": "2.1.1",
-                "function.prototype.name": "1.1.2",
-                "is-regex": "1.1.0",
-                "object-is": "1.1.2",
-                "object.assign": "4.1.0",
-                "object.entries": "1.1.2",
-                "prop-types": "15.7.2",
-                "prop-types-exact": "1.2.0",
-                "react-is": "16.13.1"
+                "array.prototype.find": "^2.1.1",
+                "function.prototype.name": "^1.1.2",
+                "is-regex": "^1.1.0",
+                "object-is": "^1.1.2",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.1.2",
+                "prop-types": "^15.7.2",
+                "prop-types-exact": "^1.2.0",
+                "react-is": "^16.13.1"
             }
         },
         "ajv": {
@@ -2001,16 +2001,17 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
             "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
             "requires": {
-                "fast-deep-equal": "3.1.3",
-                "fast-json-stable-stringify": "2.1.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ajv-errors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+            "dev": true
         },
         "ajv-keywords": {
             "version": "3.5.0",
@@ -2029,7 +2030,7 @@
             "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
             "dev": true,
             "requires": {
-                "type-fest": "0.11.0"
+                "type-fest": "^0.11.0"
             },
             "dependencies": {
                 "type-fest": {
@@ -2050,7 +2051,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
             }
         },
         "any-promise": {
@@ -2064,8 +2065,8 @@
             "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
             "dev": true,
             "requires": {
-                "normalize-path": "3.0.0",
-                "picomatch": "2.2.2"
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
             }
         },
         "aproba": {
@@ -2078,7 +2079,7 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "aria-query": {
@@ -2087,8 +2088,8 @@
             "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "7.10.4",
-                "@babel/runtime-corejs3": "7.10.4"
+                "@babel/runtime": "^7.10.2",
+                "@babel/runtime-corejs3": "^7.10.2"
             }
         },
         "arr-diff": {
@@ -2126,9 +2127,9 @@
             "integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "is-string": "1.0.5"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0",
+                "is-string": "^1.0.5"
             }
         },
         "array-union": {
@@ -2136,7 +2137,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -2156,8 +2157,8 @@
             "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.4"
             }
         },
         "array.prototype.flat": {
@@ -2166,8 +2167,8 @@
             "integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "array.prototype.flatmap": {
@@ -2176,9 +2177,9 @@
             "integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1"
             }
         },
         "asap": {
@@ -2194,7 +2195,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "asn1.js": {
@@ -2203,9 +2204,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "inherits": "2.0.4",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -2222,7 +2223,7 @@
             "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
+                "object-assign": "^4.1.1",
                 "util": "0.10.3"
             },
             "dependencies": {
@@ -2321,14 +2322,14 @@
             "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
             "dev": true,
             "requires": {
-                "@jest/transform": "26.1.0",
-                "@jest/types": "26.1.0",
-                "@types/babel__core": "7.1.9",
-                "babel-plugin-istanbul": "6.0.0",
-                "babel-preset-jest": "26.1.0",
-                "chalk": "4.1.0",
-                "graceful-fs": "4.2.4",
-                "slash": "3.0.0"
+                "@jest/transform": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "@types/babel__core": "^7.1.7",
+                "babel-plugin-istanbul": "^6.0.0",
+                "babel-preset-jest": "^26.1.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -2337,10 +2338,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -2349,8 +2350,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -2359,8 +2360,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -2369,7 +2370,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -2390,7 +2391,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -2401,11 +2402,11 @@
             "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "7.10.4",
-                "@istanbuljs/load-nyc-config": "1.1.0",
-                "@istanbuljs/schema": "0.1.2",
-                "istanbul-lib-instrument": "4.0.3",
-                "test-exclude": "6.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@istanbuljs/load-nyc-config": "^1.0.0",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-instrument": "^4.0.0",
+                "test-exclude": "^6.0.0"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -2414,10 +2415,10 @@
             "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
             "dev": true,
             "requires": {
-                "@babel/template": "7.10.4",
-                "@babel/types": "7.10.4",
-                "@types/babel__core": "7.1.9",
-                "@types/babel__traverse": "7.0.12"
+                "@babel/template": "^7.3.3",
+                "@babel/types": "^7.3.3",
+                "@types/babel__core": "^7.0.0",
+                "@types/babel__traverse": "^7.0.6"
             }
         },
         "babel-plugin-react-svg": {
@@ -2431,17 +2432,17 @@
             "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
             "dev": true,
             "requires": {
-                "@babel/plugin-syntax-async-generators": "7.8.4",
-                "@babel/plugin-syntax-bigint": "7.8.3",
-                "@babel/plugin-syntax-class-properties": "7.10.4",
-                "@babel/plugin-syntax-import-meta": "7.10.4",
-                "@babel/plugin-syntax-json-strings": "7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "7.8.3"
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             }
         },
         "babel-preset-jest": {
@@ -2450,8 +2451,8 @@
             "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
             "dev": true,
             "requires": {
-                "babel-plugin-jest-hoist": "26.1.0",
-                "babel-preset-current-node-syntax": "0.1.3"
+                "babel-plugin-jest-hoist": "^26.1.0",
+                "babel-preset-current-node-syntax": "^0.1.2"
             }
         },
         "balanced-match": {
@@ -2465,13 +2466,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.3.0",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.2",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2480,7 +2481,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2489,7 +2490,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2498,7 +2499,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2507,9 +2508,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.3"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -2526,7 +2527,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "bfj": {
@@ -2534,10 +2535,10 @@
             "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
             "integrity": "sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==",
             "requires": {
-                "bluebird": "3.7.2",
-                "check-types": "8.0.3",
-                "hoopy": "0.1.4",
-                "tryer": "1.0.1"
+                "bluebird": "^3.5.5",
+                "check-types": "^8.0.3",
+                "hoopy": "^0.1.4",
+                "tryer": "^1.0.1"
             }
         },
         "big.js": {
@@ -2569,15 +2570,15 @@
             "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
             "requires": {
                 "bytes": "3.1.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "http-errors": "1.7.2",
                 "iconv-lite": "0.4.24",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.7.0",
                 "raw-body": "2.4.0",
-                "type-is": "1.6.18"
+                "type-is": "~1.6.17"
             },
             "dependencies": {
                 "debug": {
@@ -2605,7 +2606,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2615,7 +2616,7 @@
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
             "dev": true,
             "requires": {
-                "fill-range": "7.0.1"
+                "fill-range": "^7.0.1"
             }
         },
         "brorand": {
@@ -2636,12 +2637,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.4",
-                "safe-buffer": "5.1.2"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -2650,9 +2651,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.2",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -2661,10 +2662,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.1",
-                "inherits": "2.0.4",
-                "safe-buffer": "5.1.2"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
             }
         },
         "browserify-rsa": {
@@ -2673,8 +2674,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "randombytes": "2.1.0"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             },
             "dependencies": {
                 "bn.js": {
@@ -2691,15 +2692,15 @@
             "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
             "dev": true,
             "requires": {
-                "bn.js": "5.1.2",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.5.3",
-                "inherits": "2.0.4",
-                "parse-asn1": "5.1.5",
-                "readable-stream": "3.6.0",
-                "safe-buffer": "5.2.1"
+                "bn.js": "^5.1.1",
+                "browserify-rsa": "^4.0.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.2",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.5",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
             },
             "dependencies": {
                 "readable-stream": {
@@ -2708,9 +2709,9 @@
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.4",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 },
                 "safe-buffer": {
@@ -2727,7 +2728,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.11"
+                "pako": "~1.0.5"
             }
         },
         "bs-logger": {
@@ -2736,7 +2737,7 @@
             "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
             "dev": true,
             "requires": {
-                "fast-json-stable-stringify": "2.1.0"
+                "fast-json-stable-stringify": "2.x"
             }
         },
         "bser": {
@@ -2745,7 +2746,7 @@
             "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
             "dev": true,
             "requires": {
-                "node-int64": "0.4.0"
+                "node-int64": "^0.4.0"
             }
         },
         "buffer": {
@@ -2754,9 +2755,9 @@
             "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "dev": true,
             "requires": {
-                "base64-js": "1.3.1",
-                "ieee754": "1.1.13",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-from": {
@@ -2785,22 +2786,23 @@
             "version": "12.0.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
             "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+            "dev": true,
             "requires": {
-                "bluebird": "3.7.2",
-                "chownr": "1.1.4",
-                "figgy-pudding": "3.5.2",
-                "glob": "7.1.6",
-                "graceful-fs": "4.2.4",
-                "infer-owner": "1.0.4",
-                "lru-cache": "5.1.1",
-                "mississippi": "3.0.0",
-                "mkdirp": "0.5.5",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.7.1",
-                "ssri": "6.0.1",
-                "unique-filename": "1.1.1",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.5",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
+                "y18n": "^4.0.0"
             }
         },
         "cache-base": {
@@ -2809,15 +2811,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.3.0",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.1",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.1",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "callsites": {
@@ -2837,7 +2839,7 @@
             "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "dev": true,
             "requires": {
-                "rsvp": "4.8.5"
+                "rsvp": "^4.8.4"
             }
         },
         "caseless": {
@@ -2851,9 +2853,9 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "char-regex": {
@@ -2873,12 +2875,12 @@
             "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.1",
-                "entities": "1.1.2",
-                "htmlparser2": "3.10.1",
-                "lodash": "4.17.15",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.1",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             },
             "dependencies": {
                 "css-select": {
@@ -2887,10 +2889,10 @@
                     "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
                     "dev": true,
                     "requires": {
-                        "boolbase": "1.0.0",
-                        "css-what": "2.1.3",
+                        "boolbase": "~1.0.0",
+                        "css-what": "2.1",
                         "domutils": "1.5.1",
-                        "nth-check": "1.0.2"
+                        "nth-check": "~1.0.1"
                     }
                 },
                 "css-what": {
@@ -2905,8 +2907,8 @@
                     "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.1",
-                        "entities": "1.1.2"
+                        "domelementtype": "^1.3.0",
+                        "entities": "^1.1.1"
                     }
                 },
                 "domutils": {
@@ -2915,8 +2917,8 @@
                     "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
                     "dev": true,
                     "requires": {
-                        "dom-serializer": "0.1.1",
-                        "domelementtype": "1.3.1"
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
                     }
                 },
                 "entities": {
@@ -2934,14 +2936,14 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "anymatch": "3.1.1",
-                "braces": "3.0.2",
-                "fsevents": "2.1.3",
-                "glob-parent": "5.1.1",
-                "is-binary-path": "2.1.0",
-                "is-glob": "4.0.1",
-                "normalize-path": "3.0.0",
-                "readdirp": "3.4.0"
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.4.0"
             }
         },
         "chownr": {
@@ -2955,7 +2957,7 @@
             "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
             "dev": true,
             "requires": {
-                "tslib": "1.13.0"
+                "tslib": "^1.9.0"
             }
         },
         "ci-info": {
@@ -2970,8 +2972,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "class-utils": {
@@ -2980,10 +2982,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2992,7 +2994,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -3008,8 +3010,8 @@
             "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
             "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
             "requires": {
-                "@types/webpack": "4.41.18",
-                "del": "4.1.1"
+                "@types/webpack": "^4.4.31",
+                "del": "^4.1.1"
             }
         },
         "cli-cursor": {
@@ -3018,7 +3020,7 @@
             "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
             "dev": true,
             "requires": {
-                "restore-cursor": "3.1.0"
+                "restore-cursor": "^3.1.0"
             }
         },
         "cli-truncate": {
@@ -3027,8 +3029,8 @@
             "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
             "dev": true,
             "requires": {
-                "slice-ansi": "3.0.0",
-                "string-width": "4.2.0"
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3037,8 +3039,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "astral-regex": {
@@ -3053,7 +3055,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -3068,9 +3070,9 @@
                     "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "astral-regex": "2.0.0",
-                        "is-fullwidth-code-point": "3.0.0"
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
                     }
                 }
             }
@@ -3080,9 +3082,9 @@
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
             "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
             "requires": {
-                "string-width": "4.2.0",
-                "strip-ansi": "6.0.0",
-                "wrap-ansi": "6.2.0"
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^6.2.0"
             }
         },
         "clone": {
@@ -3102,9 +3104,9 @@
             "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
             "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
             "requires": {
-                "@types/q": "1.5.4",
-                "chalk": "2.4.2",
-                "q": "1.5.1"
+                "@types/q": "^1.5.1",
+                "chalk": "^2.4.1",
+                "q": "^1.1.2"
             }
         },
         "collect-v8-coverage": {
@@ -3119,8 +3121,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -3142,7 +3144,7 @@
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -3177,10 +3179,10 @@
             "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "confusing-browser-globals": {
@@ -3225,7 +3227,7 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
             "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.1"
             }
         },
         "cookie": {
@@ -3243,12 +3245,12 @@
             "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.5",
-                "rimraf": "2.7.1",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -3274,11 +3276,11 @@
             "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
             "dev": true,
             "requires": {
-                "@types/parse-json": "4.0.0",
-                "import-fresh": "3.2.1",
-                "parse-json": "5.0.0",
-                "path-type": "4.0.0",
-                "yaml": "1.10.0"
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.1.0",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.7.2"
             },
             "dependencies": {
                 "parse-json": {
@@ -3287,10 +3289,10 @@
                     "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "7.10.4",
-                        "error-ex": "1.3.2",
-                        "json-parse-better-errors": "1.0.2",
-                        "lines-and-columns": "1.1.6"
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
                     }
                 },
                 "path-type": {
@@ -3307,8 +3309,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "elliptic": "6.5.3"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -3325,11 +3327,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.4",
-                "md5.js": "1.3.5",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -3338,12 +3340,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.4",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-spawn": {
@@ -3352,9 +3354,9 @@
             "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
             "dev": true,
             "requires": {
-                "path-key": "3.1.1",
-                "shebang-command": "2.0.0",
-                "which": "2.0.2"
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
             }
         },
         "crypto-browserify": {
@@ -3363,17 +3365,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.2.0",
-                "create-ecdh": "4.0.3",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.4",
-                "pbkdf2": "3.1.1",
-                "public-encrypt": "4.0.3",
-                "randombytes": "2.1.0",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css-loader": {
@@ -3382,19 +3384,19 @@
             "integrity": "sha512-M5lSukoWi1If8dhQAUCvj4H8vUt3vOnwbQBH9DdTm/s4Ym2B/3dPMtYZeJmq7Q3S3Pa+I94DcZ7pc9bP14cWIQ==",
             "dev": true,
             "requires": {
-                "camelcase": "5.3.1",
-                "cssesc": "3.0.0",
-                "icss-utils": "4.1.1",
-                "loader-utils": "1.4.0",
-                "normalize-path": "3.0.0",
-                "postcss": "7.0.32",
-                "postcss-modules-extract-imports": "2.0.0",
-                "postcss-modules-local-by-default": "3.0.2",
-                "postcss-modules-scope": "2.2.0",
-                "postcss-modules-values": "3.0.0",
-                "postcss-value-parser": "4.1.0",
-                "schema-utils": "2.7.0",
-                "semver": "6.3.0"
+                "camelcase": "^5.3.1",
+                "cssesc": "^3.0.0",
+                "icss-utils": "^4.1.1",
+                "loader-utils": "^1.2.3",
+                "normalize-path": "^3.0.0",
+                "postcss": "^7.0.32",
+                "postcss-modules-extract-imports": "^2.0.0",
+                "postcss-modules-local-by-default": "^3.0.2",
+                "postcss-modules-scope": "^2.2.0",
+                "postcss-modules-values": "^3.0.0",
+                "postcss-value-parser": "^4.1.0",
+                "schema-utils": "^2.7.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "schema-utils": {
@@ -3403,9 +3405,9 @@
                     "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
                     "dev": true,
                     "requires": {
-                        "@types/json-schema": "7.0.5",
-                        "ajv": "6.12.2",
-                        "ajv-keywords": "3.5.0"
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
                     }
                 },
                 "semver": {
@@ -3421,10 +3423,10 @@
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
             "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "3.3.0",
-                "domutils": "1.7.0",
-                "nth-check": "1.0.2"
+                "boolbase": "^1.0.0",
+                "css-what": "^3.2.1",
+                "domutils": "^1.7.0",
+                "nth-check": "^1.0.2"
             }
         },
         "css-select-base-adapter": {
@@ -3438,7 +3440,7 @@
             "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
             "requires": {
                 "mdn-data": "2.0.4",
-                "source-map": "0.6.1"
+                "source-map": "^0.6.1"
             }
         },
         "css-what": {
@@ -3466,7 +3468,7 @@
                     "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
                     "requires": {
                         "mdn-data": "2.0.6",
-                        "source-map": "0.6.1"
+                        "source-map": "^0.6.1"
                     }
                 },
                 "mdn-data": {
@@ -3488,7 +3490,7 @@
             "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.8"
+                "cssom": "~0.3.6"
             },
             "dependencies": {
                 "cssom": {
@@ -3522,7 +3524,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "data-urls": {
@@ -3531,9 +3533,9 @@
             "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
             "dev": true,
             "requires": {
-                "abab": "2.0.3",
-                "whatwg-mimetype": "2.3.0",
-                "whatwg-url": "8.1.0"
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
             }
         },
         "debug": {
@@ -3541,7 +3543,7 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "requires": {
-                "ms": "2.1.2"
+                "ms": "^2.1.1"
             }
         },
         "decamelize": {
@@ -3584,7 +3586,7 @@
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "requires": {
-                "object-keys": "1.1.1"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -3593,8 +3595,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -3603,7 +3605,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -3612,7 +3614,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -3621,9 +3623,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.3"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -3633,13 +3635,13 @@
             "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
             "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
             "requires": {
-                "@types/glob": "7.1.3",
-                "globby": "6.1.0",
-                "is-path-cwd": "2.2.0",
-                "is-path-in-cwd": "2.1.0",
-                "p-map": "2.1.0",
-                "pify": "4.0.1",
-                "rimraf": "2.7.1"
+                "@types/glob": "^7.1.1",
+                "globby": "^6.1.0",
+                "is-path-cwd": "^2.0.0",
+                "is-path-in-cwd": "^2.0.0",
+                "p-map": "^2.0.0",
+                "pify": "^4.0.1",
+                "rimraf": "^2.6.3"
             }
         },
         "delayed-stream": {
@@ -3659,8 +3661,8 @@
             "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -3692,9 +3694,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.1.0"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -3717,7 +3719,7 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.3"
+                "esutils": "^2.0.2"
             }
         },
         "dom-serializer": {
@@ -3725,8 +3727,8 @@
             "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
             "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
             "requires": {
-                "domelementtype": "2.0.1",
-                "entities": "2.0.3"
+                "domelementtype": "^2.0.1",
+                "entities": "^2.0.0"
             },
             "dependencies": {
                 "domelementtype": {
@@ -3753,7 +3755,7 @@
             "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "5.0.0"
+                "webidl-conversions": "^5.0.0"
             },
             "dependencies": {
                 "webidl-conversions": {
@@ -3770,7 +3772,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.1"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -3778,8 +3780,8 @@
             "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "requires": {
-                "dom-serializer": "0.2.2",
-                "domelementtype": "1.3.1"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -3792,10 +3794,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
             "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "requires": {
-                "end-of-stream": "1.4.4",
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7",
-                "stream-shift": "1.0.1"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -3804,8 +3806,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ee-first": {
@@ -3824,13 +3826,13 @@
             "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.7",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.4",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             },
             "dependencies": {
                 "bn.js": {
@@ -3861,7 +3863,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -3870,9 +3872,9 @@
             "integrity": "sha512-S7eiFb/erugyd1rLb6mQ3Vuq+EXHv5cpCkNqqIkYkBgN2QdFnyCZzFBleqwGEx4lgNGYij81BWnCrFNK7vxvjQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.2.4",
-                "memory-fs": "0.5.0",
-                "tapable": "1.1.3"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.5.0",
+                "tapable": "^1.0.0"
             }
         },
         "enquirer": {
@@ -3881,7 +3883,7 @@
             "integrity": "sha512-BNT1C08P9XD0vNg3J475yIUG+mVdp9T6towYFHUv897X0KoHBjB1shyrNmhmtHWKP17iSWgo7Gqh7BBuzLZMSA==",
             "dev": true,
             "requires": {
-                "ansi-colors": "3.2.4"
+                "ansi-colors": "^3.2.1"
             }
         },
         "entities": {
@@ -3895,28 +3897,28 @@
             "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
             "dev": true,
             "requires": {
-                "array.prototype.flat": "1.2.3",
-                "cheerio": "1.0.0-rc.3",
-                "enzyme-shallow-equal": "1.0.1",
-                "function.prototype.name": "1.1.2",
-                "has": "1.0.3",
-                "html-element-map": "1.2.0",
-                "is-boolean-object": "1.0.1",
-                "is-callable": "1.2.0",
-                "is-number-object": "1.0.4",
-                "is-regex": "1.1.0",
-                "is-string": "1.0.5",
-                "is-subset": "0.1.1",
-                "lodash.escape": "4.0.1",
-                "lodash.isequal": "4.5.0",
-                "object-inspect": "1.8.0",
-                "object-is": "1.1.2",
-                "object.assign": "4.1.0",
-                "object.entries": "1.1.2",
-                "object.values": "1.1.1",
-                "raf": "3.4.1",
-                "rst-selector-parser": "2.2.3",
-                "string.prototype.trim": "1.2.1"
+                "array.prototype.flat": "^1.2.3",
+                "cheerio": "^1.0.0-rc.3",
+                "enzyme-shallow-equal": "^1.0.1",
+                "function.prototype.name": "^1.1.2",
+                "has": "^1.0.3",
+                "html-element-map": "^1.2.0",
+                "is-boolean-object": "^1.0.1",
+                "is-callable": "^1.1.5",
+                "is-number-object": "^1.0.4",
+                "is-regex": "^1.0.5",
+                "is-string": "^1.0.5",
+                "is-subset": "^0.1.1",
+                "lodash.escape": "^4.0.1",
+                "lodash.isequal": "^4.5.0",
+                "object-inspect": "^1.7.0",
+                "object-is": "^1.0.2",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.1.1",
+                "object.values": "^1.1.1",
+                "raf": "^3.4.1",
+                "rst-selector-parser": "^2.2.3",
+                "string.prototype.trim": "^1.2.1"
             }
         },
         "enzyme-adapter-react-16": {
@@ -3925,15 +3927,15 @@
             "integrity": "sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==",
             "dev": true,
             "requires": {
-                "enzyme-adapter-utils": "1.13.0",
-                "enzyme-shallow-equal": "1.0.1",
-                "has": "1.0.3",
-                "object.assign": "4.1.0",
-                "object.values": "1.1.1",
-                "prop-types": "15.7.2",
-                "react-is": "16.13.1",
-                "react-test-renderer": "16.13.1",
-                "semver": "5.7.1"
+                "enzyme-adapter-utils": "^1.13.0",
+                "enzyme-shallow-equal": "^1.0.1",
+                "has": "^1.0.3",
+                "object.assign": "^4.1.0",
+                "object.values": "^1.1.1",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.12.0",
+                "react-test-renderer": "^16.0.0-0",
+                "semver": "^5.7.0"
             }
         },
         "enzyme-adapter-utils": {
@@ -3942,12 +3944,12 @@
             "integrity": "sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==",
             "dev": true,
             "requires": {
-                "airbnb-prop-types": "2.16.0",
-                "function.prototype.name": "1.1.2",
-                "object.assign": "4.1.0",
-                "object.fromentries": "2.0.2",
-                "prop-types": "15.7.2",
-                "semver": "5.7.1"
+                "airbnb-prop-types": "^2.15.0",
+                "function.prototype.name": "^1.1.2",
+                "object.assign": "^4.1.0",
+                "object.fromentries": "^2.0.2",
+                "prop-types": "^15.7.2",
+                "semver": "^5.7.1"
             }
         },
         "enzyme-shallow-equal": {
@@ -3956,8 +3958,8 @@
             "integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
             "dev": true,
             "requires": {
-                "has": "1.0.3",
-                "object-is": "1.1.2"
+                "has": "^1.0.3",
+                "object-is": "^1.0.2"
             }
         },
         "errno": {
@@ -3965,7 +3967,7 @@
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error-ex": {
@@ -3974,7 +3976,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -3982,17 +3984,17 @@
             "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
             "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
             "requires": {
-                "es-to-primitive": "1.2.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "has-symbols": "1.0.1",
-                "is-callable": "1.2.0",
-                "is-regex": "1.1.0",
-                "object-inspect": "1.8.0",
-                "object-keys": "1.1.1",
-                "object.assign": "4.1.0",
-                "string.prototype.trimend": "1.0.1",
-                "string.prototype.trimstart": "1.0.1"
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.0",
+                "is-regex": "^1.1.0",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
             }
         },
         "es-to-primitive": {
@@ -4000,9 +4002,9 @@
             "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "requires": {
-                "is-callable": "1.2.0",
-                "is-date-object": "1.0.2",
-                "is-symbol": "1.0.3"
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
             }
         },
         "escape-html": {
@@ -4021,11 +4023,11 @@
             "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
             "dev": true,
             "requires": {
-                "esprima": "4.0.1",
-                "estraverse": "4.3.0",
-                "esutils": "2.0.3",
-                "optionator": "0.8.3",
-                "source-map": "0.6.1"
+                "esprima": "^4.0.1",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "levn": {
@@ -4034,8 +4036,8 @@
                     "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                     "dev": true,
                     "requires": {
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2"
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2"
                     }
                 },
                 "optionator": {
@@ -4044,12 +4046,12 @@
                     "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
                     "dev": true,
                     "requires": {
-                        "deep-is": "0.1.3",
-                        "fast-levenshtein": "2.0.6",
-                        "levn": "0.3.0",
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2",
-                        "word-wrap": "1.2.3"
+                        "deep-is": "~0.1.3",
+                        "fast-levenshtein": "~2.0.6",
+                        "levn": "~0.3.0",
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2",
+                        "word-wrap": "~1.2.3"
                     }
                 },
                 "prelude-ls": {
@@ -4064,7 +4066,7 @@
                     "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                     "dev": true,
                     "requires": {
-                        "prelude-ls": "1.1.2"
+                        "prelude-ls": "~1.1.2"
                     }
                 }
             }
@@ -4075,42 +4077,42 @@
             "integrity": "sha512-cQC/xj9bhWUcyi/RuMbRtC3I0eW8MH0jhRELSvpKYkWep3C6YZ2OkvcvJVUeO6gcunABmzptbXBuDoXsjHmfTA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.10.4",
-                "ajv": "6.12.2",
-                "chalk": "4.1.0",
-                "cross-spawn": "7.0.3",
-                "debug": "4.1.1",
-                "doctrine": "3.0.0",
-                "enquirer": "2.3.5",
-                "eslint-scope": "5.1.0",
-                "eslint-utils": "2.1.0",
-                "eslint-visitor-keys": "1.3.0",
-                "espree": "7.1.0",
-                "esquery": "1.3.1",
-                "esutils": "2.0.3",
-                "file-entry-cache": "5.0.1",
-                "functional-red-black-tree": "1.0.1",
-                "glob-parent": "5.1.1",
-                "globals": "12.4.0",
-                "ignore": "4.0.6",
-                "import-fresh": "3.2.1",
-                "imurmurhash": "0.1.4",
-                "is-glob": "4.0.1",
-                "js-yaml": "3.14.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.4.1",
-                "lodash": "4.17.15",
-                "minimatch": "3.0.4",
-                "natural-compare": "1.4.0",
-                "optionator": "0.9.1",
-                "progress": "2.0.3",
-                "regexpp": "3.1.0",
-                "semver": "7.3.2",
-                "strip-ansi": "6.0.0",
-                "strip-json-comments": "3.1.0",
-                "table": "5.4.6",
-                "text-table": "0.2.0",
-                "v8-compile-cache": "2.1.1"
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.0",
+                "eslint-utils": "^2.0.0",
+                "eslint-visitor-keys": "^1.2.0",
+                "espree": "^7.1.0",
+                "esquery": "^1.2.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.14",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "progress": "^2.0.0",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -4119,8 +4121,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -4129,8 +4131,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -4139,7 +4141,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -4154,7 +4156,7 @@
                     "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
                     "dev": true,
                     "requires": {
-                        "type-fest": "0.8.1"
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "has-flag": {
@@ -4175,7 +4177,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -4186,9 +4188,9 @@
             "integrity": "sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==",
             "dev": true,
             "requires": {
-                "eslint-config-airbnb-base": "14.2.0",
-                "object.assign": "4.1.0",
-                "object.entries": "1.1.2"
+                "eslint-config-airbnb-base": "^14.2.0",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.1.2"
             }
         },
         "eslint-config-airbnb-base": {
@@ -4197,9 +4199,9 @@
             "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
             "dev": true,
             "requires": {
-                "confusing-browser-globals": "1.0.9",
-                "object.assign": "4.1.0",
-                "object.entries": "1.1.2"
+                "confusing-browser-globals": "^1.0.9",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.1.2"
             }
         },
         "eslint-config-airbnb-typescript": {
@@ -4208,9 +4210,9 @@
             "integrity": "sha512-TCOftyCoIogJzzLGSg0Qlxd27qvf+1a3MHyN/PqynTqINS4iFy+SlXy/CrAN+6xkleGMSrvmPbm3pyFEku2+IQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/parser": "3.5.0",
-                "eslint-config-airbnb": "18.2.0",
-                "eslint-config-airbnb-base": "14.2.0"
+                "@typescript-eslint/parser": "^3.1.0",
+                "eslint-config-airbnb": "^18.1.0",
+                "eslint-config-airbnb-base": "^14.1.0"
             }
         },
         "eslint-import-resolver-node": {
@@ -4219,8 +4221,8 @@
             "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "resolve": "1.17.0"
+                "debug": "^2.6.9",
+                "resolve": "^1.13.1"
             },
             "dependencies": {
                 "debug": {
@@ -4246,11 +4248,11 @@
             "integrity": "sha512-EDpXor6lsjtTzZpLUn7KmXs02+nIjGcgees9BYjNkWra3jVq5vVa8IoCKgzT2M7dNNeoMBtaSG83Bd40N3poLw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "3.3.1",
-                "fs-extra": "8.1.0",
-                "loader-utils": "2.0.0",
-                "object-hash": "2.0.3",
-                "schema-utils": "2.7.0"
+                "find-cache-dir": "^3.3.1",
+                "fs-extra": "^8.1.0",
+                "loader-utils": "^2.0.0",
+                "object-hash": "^2.0.3",
+                "schema-utils": "^2.6.5"
             },
             "dependencies": {
                 "find-cache-dir": {
@@ -4259,9 +4261,9 @@
                     "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
                     "dev": true,
                     "requires": {
-                        "commondir": "1.0.1",
-                        "make-dir": "3.1.0",
-                        "pkg-dir": "4.2.0"
+                        "commondir": "^1.0.1",
+                        "make-dir": "^3.0.2",
+                        "pkg-dir": "^4.1.0"
                     }
                 },
                 "find-up": {
@@ -4270,8 +4272,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "fs-extra": {
@@ -4280,9 +4282,9 @@
                     "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.4",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.2"
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "json5": {
@@ -4291,7 +4293,7 @@
                     "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.5"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "jsonfile": {
@@ -4300,7 +4302,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.4"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "loader-utils": {
@@ -4309,9 +4311,9 @@
                     "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
                     "dev": true,
                     "requires": {
-                        "big.js": "5.2.2",
-                        "emojis-list": "3.0.0",
-                        "json5": "2.1.3"
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
                     }
                 },
                 "locate-path": {
@@ -4320,7 +4322,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "make-dir": {
@@ -4329,7 +4331,7 @@
                     "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
-                        "semver": "6.3.0"
+                        "semver": "^6.0.0"
                     }
                 },
                 "p-locate": {
@@ -4338,7 +4340,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -4353,7 +4355,7 @@
                     "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
                     "dev": true,
                     "requires": {
-                        "find-up": "4.1.0"
+                        "find-up": "^4.0.0"
                     }
                 },
                 "schema-utils": {
@@ -4362,9 +4364,9 @@
                     "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
                     "dev": true,
                     "requires": {
-                        "@types/json-schema": "7.0.5",
-                        "ajv": "6.12.2",
-                        "ajv-keywords": "3.5.0"
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
                     }
                 },
                 "semver": {
@@ -4381,8 +4383,8 @@
             "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "pkg-dir": "2.0.0"
+                "debug": "^2.6.9",
+                "pkg-dir": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -4400,7 +4402,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "locate-path": {
@@ -4409,8 +4411,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "ms": {
@@ -4425,7 +4427,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "1.0.0"
+                        "p-try": "^1.0.0"
                     }
                 },
                 "p-locate": {
@@ -4434,7 +4436,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "1.3.0"
+                        "p-limit": "^1.1.0"
                     }
                 },
                 "p-try": {
@@ -4449,7 +4451,7 @@
                     "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0"
+                        "find-up": "^2.1.0"
                     }
                 }
             }
@@ -4460,19 +4462,19 @@
             "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
             "dev": true,
             "requires": {
-                "array-includes": "3.1.1",
-                "array.prototype.flat": "1.2.3",
-                "contains-path": "0.1.0",
-                "debug": "2.6.9",
+                "array-includes": "^3.1.1",
+                "array.prototype.flat": "^1.2.3",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.9",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "0.3.4",
-                "eslint-module-utils": "2.6.0",
-                "has": "1.0.3",
-                "minimatch": "3.0.4",
-                "object.values": "1.1.1",
-                "read-pkg-up": "2.0.0",
-                "resolve": "1.17.0",
-                "tsconfig-paths": "3.9.0"
+                "eslint-import-resolver-node": "^0.3.3",
+                "eslint-module-utils": "^2.6.0",
+                "has": "^1.0.3",
+                "minimatch": "^3.0.4",
+                "object.values": "^1.1.1",
+                "read-pkg-up": "^2.0.0",
+                "resolve": "^1.17.0",
+                "tsconfig-paths": "^3.9.0"
             },
             "dependencies": {
                 "debug": {
@@ -4490,8 +4492,8 @@
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.3",
-                        "isarray": "1.0.0"
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
                     }
                 },
                 "ms": {
@@ -4508,17 +4510,17 @@
             "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "7.10.4",
-                "aria-query": "4.2.2",
-                "array-includes": "3.1.1",
-                "ast-types-flow": "0.0.7",
-                "axe-core": "3.5.5",
-                "axobject-query": "2.2.0",
-                "damerau-levenshtein": "1.0.6",
-                "emoji-regex": "9.0.0",
-                "has": "1.0.3",
-                "jsx-ast-utils": "2.4.1",
-                "language-tags": "1.0.5"
+                "@babel/runtime": "^7.10.2",
+                "aria-query": "^4.2.2",
+                "array-includes": "^3.1.1",
+                "ast-types-flow": "^0.0.7",
+                "axe-core": "^3.5.4",
+                "axobject-query": "^2.1.2",
+                "damerau-levenshtein": "^1.0.6",
+                "emoji-regex": "^9.0.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.4.1",
+                "language-tags": "^1.0.5"
             },
             "dependencies": {
                 "emoji-regex": {
@@ -4535,17 +4537,17 @@
             "integrity": "sha512-txbo090buDeyV0ugF3YMWrzLIUqpYTsWSDZV9xLSmExE1P/Kmgg9++PD931r+KEWS66O1c9R4srLVVHmeHpoAg==",
             "dev": true,
             "requires": {
-                "array-includes": "3.1.1",
-                "array.prototype.flatmap": "1.2.3",
-                "doctrine": "2.1.0",
-                "has": "1.0.3",
-                "jsx-ast-utils": "2.4.1",
-                "object.entries": "1.1.2",
-                "object.fromentries": "2.0.2",
-                "object.values": "1.1.1",
-                "prop-types": "15.7.2",
-                "resolve": "1.17.0",
-                "string.prototype.matchall": "4.0.2"
+                "array-includes": "^3.1.1",
+                "array.prototype.flatmap": "^1.2.3",
+                "doctrine": "^2.1.0",
+                "has": "^1.0.3",
+                "jsx-ast-utils": "^2.4.1",
+                "object.entries": "^1.1.2",
+                "object.fromentries": "^2.0.2",
+                "object.values": "^1.1.1",
+                "prop-types": "^15.7.2",
+                "resolve": "^1.17.0",
+                "string.prototype.matchall": "^4.0.2"
             },
             "dependencies": {
                 "doctrine": {
@@ -4554,7 +4556,7 @@
                     "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.3"
+                        "esutils": "^2.0.2"
                     }
                 }
             }
@@ -4571,8 +4573,8 @@
             "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.3.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-utils": {
@@ -4581,7 +4583,7 @@
             "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "1.3.0"
+                "eslint-visitor-keys": "^1.1.0"
             }
         },
         "eslint-visitor-keys": {
@@ -4596,9 +4598,9 @@
             "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
             "dev": true,
             "requires": {
-                "acorn": "7.3.1",
-                "acorn-jsx": "5.2.0",
-                "eslint-visitor-keys": "1.3.0"
+                "acorn": "^7.2.0",
+                "acorn-jsx": "^5.2.0",
+                "eslint-visitor-keys": "^1.2.0"
             }
         },
         "esprima": {
@@ -4612,7 +4614,7 @@
             "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
             "dev": true,
             "requires": {
-                "estraverse": "5.1.0"
+                "estraverse": "^5.1.0"
             },
             "dependencies": {
                 "estraverse": {
@@ -4629,7 +4631,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.3.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -4661,8 +4663,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.5",
-                "safe-buffer": "5.1.2"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "exec-sh": {
@@ -4677,13 +4679,13 @@
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "get-stream": "4.1.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.3",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -4692,11 +4694,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.5",
-                        "path-key": "2.0.1",
-                        "semver": "5.7.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "path-key": {
@@ -4711,7 +4713,7 @@
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -4726,7 +4728,7 @@
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -4743,13 +4745,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -4767,7 +4769,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -4776,7 +4778,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "ms": {
@@ -4793,7 +4795,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.3"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "expect": {
@@ -4802,12 +4804,12 @@
             "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "ansi-styles": "4.2.1",
-                "jest-get-type": "26.0.0",
-                "jest-matcher-utils": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-regex-util": "26.0.0"
+                "@jest/types": "^26.1.0",
+                "ansi-styles": "^4.0.0",
+                "jest-get-type": "^26.0.0",
+                "jest-matcher-utils": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-regex-util": "^26.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -4816,10 +4818,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -4828,8 +4830,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -4838,8 +4840,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -4848,7 +4850,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -4875,7 +4877,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -4885,36 +4887,36 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
             "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
             "requires": {
-                "accepts": "1.3.7",
+                "accepts": "~1.3.7",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.19.0",
                 "content-disposition": "0.5.3",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.4.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
-                "finalhandler": "1.1.2",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.3",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.6",
+                "proxy-addr": "~2.0.5",
                 "qs": "6.7.0",
-                "range-parser": "1.2.1",
+                "range-parser": "~1.2.1",
                 "safe-buffer": "5.1.2",
                 "send": "0.17.1",
                 "serve-static": "1.14.1",
                 "setprototypeof": "1.1.1",
-                "statuses": "1.5.0",
-                "type-is": "1.6.18",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -4944,8 +4946,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4954,7 +4956,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4965,14 +4967,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -4981,7 +4983,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -4990,7 +4992,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4999,7 +5001,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -5008,7 +5010,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -5017,9 +5019,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.3"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -5058,7 +5060,8 @@
         "figgy-pudding": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
-            "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
+            "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+            "dev": true
         },
         "figures": {
             "version": "3.2.0",
@@ -5066,7 +5069,7 @@
             "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5"
+                "escape-string-regexp": "^1.0.5"
             }
         },
         "file-entry-cache": {
@@ -5075,7 +5078,7 @@
             "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
             "dev": true,
             "requires": {
-                "flat-cache": "2.0.1"
+                "flat-cache": "^2.0.1"
             }
         },
         "filesize": {
@@ -5089,7 +5092,7 @@
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "dev": true,
             "requires": {
-                "to-regex-range": "5.0.1"
+                "to-regex-range": "^5.0.1"
             }
         },
         "finalhandler": {
@@ -5098,12 +5101,12 @@
             "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.3",
-                "statuses": "1.5.0",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -5125,18 +5128,20 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
             "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+            "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "2.1.0",
-                "pkg-dir": "3.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
             }
         },
         "find-up": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
             "requires": {
-                "locate-path": "3.0.0"
+                "locate-path": "^3.0.0"
             }
         },
         "find-versions": {
@@ -5145,7 +5150,7 @@
             "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
             "dev": true,
             "requires": {
-                "semver-regex": "2.0.0"
+                "semver-regex": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -5154,10 +5159,10 @@
             "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "4.0.1",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "braces": {
@@ -5166,16 +5171,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -5184,7 +5189,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -5195,10 +5200,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -5207,7 +5212,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -5218,7 +5223,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5227,7 +5232,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5238,19 +5243,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.3",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "to-regex-range": {
@@ -5259,8 +5264,8 @@
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
                     "requires": {
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -5271,7 +5276,7 @@
             "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
             "dev": true,
             "requires": {
-                "flatted": "2.0.2",
+                "flatted": "^2.0.0",
                 "rimraf": "2.6.3",
                 "write": "1.0.3"
             },
@@ -5282,7 +5287,7 @@
                     "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.6"
+                        "glob": "^7.1.3"
                     }
                 }
             }
@@ -5298,8 +5303,8 @@
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
             "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
             "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
             }
         },
         "for-in": {
@@ -5320,9 +5325,9 @@
             "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.8",
-                "mime-types": "2.1.27"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -5336,7 +5341,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -5349,8 +5354,8 @@
             "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-extra": {
@@ -5358,8 +5363,8 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
             "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
             "requires": {
-                "graceful-fs": "4.2.4",
-                "jsonfile": "2.4.0"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
             }
         },
         "fs-promise": {
@@ -5367,10 +5372,10 @@
             "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
             "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
             "requires": {
-                "any-promise": "1.3.0",
-                "fs-extra": "2.1.2",
-                "mz": "2.7.0",
-                "thenify-all": "1.6.0"
+                "any-promise": "^1.3.0",
+                "fs-extra": "^2.0.0",
+                "mz": "^2.6.0",
+                "thenify-all": "^1.6.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -5378,10 +5383,10 @@
             "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "requires": {
-                "graceful-fs": "4.2.4",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.3.7"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -5407,9 +5412,9 @@
             "integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "functions-have-names": "1.2.1"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "functions-have-names": "^1.2.0"
             }
         },
         "functional-red-black-tree": {
@@ -5452,7 +5457,7 @@
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "dev": true,
             "requires": {
-                "pump": "3.0.0"
+                "pump": "^3.0.0"
             }
         },
         "get-value": {
@@ -5467,7 +5472,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
@@ -5475,12 +5480,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.4",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -5489,7 +5494,7 @@
             "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
             "dev": true,
             "requires": {
-                "is-glob": "4.0.1"
+                "is-glob": "^4.0.1"
             }
         },
         "global-modules": {
@@ -5498,7 +5503,7 @@
             "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
             "dev": true,
             "requires": {
-                "global-prefix": "3.0.0"
+                "global-prefix": "^3.0.0"
             },
             "dependencies": {
                 "global-prefix": {
@@ -5507,9 +5512,9 @@
                     "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
                     "dev": true,
                     "requires": {
-                        "ini": "1.3.5",
-                        "kind-of": "6.0.3",
-                        "which": "1.3.1"
+                        "ini": "^1.3.5",
+                        "kind-of": "^6.0.2",
+                        "which": "^1.3.1"
                     }
                 },
                 "which": {
@@ -5518,7 +5523,7 @@
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -5529,11 +5534,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.3",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             },
             "dependencies": {
                 "which": {
@@ -5542,7 +5547,7 @@
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 }
             }
@@ -5557,11 +5562,11 @@
             "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.6",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5588,8 +5593,8 @@
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
             "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
             "requires": {
-                "duplexer": "0.1.1",
-                "pify": "4.0.1"
+                "duplexer": "^0.1.1",
+                "pify": "^4.0.1"
             }
         },
         "handlebars": {
@@ -5598,11 +5603,11 @@
             "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
             "dev": true,
             "requires": {
-                "minimist": "1.2.5",
-                "neo-async": "2.6.1",
-                "source-map": "0.6.1",
-                "uglify-js": "3.10.0",
-                "wordwrap": "1.0.0"
+                "minimist": "^1.2.5",
+                "neo-async": "^2.6.0",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4",
+                "wordwrap": "^1.0.0"
             }
         },
         "har-schema": {
@@ -5617,8 +5622,8 @@
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "6.12.2",
-                "har-schema": "2.0.0"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
             }
         },
         "harmony-reflect": {
@@ -5632,7 +5637,7 @@
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -5651,9 +5656,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -5662,8 +5667,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -5672,7 +5677,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5681,7 +5686,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5692,7 +5697,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5703,9 +5708,9 @@
             "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "3.6.0",
-                "safe-buffer": "5.2.1"
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
             },
             "dependencies": {
                 "readable-stream": {
@@ -5714,9 +5719,9 @@
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.4",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 },
                 "safe-buffer": {
@@ -5733,8 +5738,8 @@
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
             }
         },
         "highlight.js": {
@@ -5749,9 +5754,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.7",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoist-non-react-statics": {
@@ -5759,7 +5764,7 @@
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "requires": {
-                "react-is": "16.13.1"
+                "react-is": "^16.7.0"
             }
         },
         "homedir-polyfill": {
@@ -5768,7 +5773,7 @@
             "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hoopy": {
@@ -5788,7 +5793,7 @@
             "integrity": "sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==",
             "dev": true,
             "requires": {
-                "array-filter": "1.0.0"
+                "array-filter": "^1.0.0"
             }
         },
         "html-encoding-sniffer": {
@@ -5797,7 +5802,7 @@
             "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.5"
+                "whatwg-encoding": "^1.0.5"
             }
         },
         "html-escaper": {
@@ -5812,12 +5817,12 @@
             "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.1",
-                "domhandler": "2.4.2",
-                "domutils": "1.7.0",
-                "entities": "1.1.2",
-                "inherits": "2.0.4",
-                "readable-stream": "3.6.0"
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
             },
             "dependencies": {
                 "entities": {
@@ -5832,9 +5837,9 @@
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.4",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 }
             }
@@ -5844,10 +5849,10 @@
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
             "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.1",
-                "statuses": "1.5.0",
+                "statuses": ">= 1.5.0 < 2",
                 "toidentifier": "1.0.0"
             },
             "dependencies": {
@@ -5864,9 +5869,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.16.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -5887,16 +5892,16 @@
             "integrity": "sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==",
             "dev": true,
             "requires": {
-                "chalk": "4.1.0",
-                "ci-info": "2.0.0",
-                "compare-versions": "3.6.0",
-                "cosmiconfig": "6.0.0",
-                "find-versions": "3.2.0",
-                "opencollective-postinstall": "2.0.3",
-                "pkg-dir": "4.2.0",
-                "please-upgrade-node": "3.2.0",
-                "slash": "3.0.0",
-                "which-pm-runs": "1.0.0"
+                "chalk": "^4.0.0",
+                "ci-info": "^2.0.0",
+                "compare-versions": "^3.6.0",
+                "cosmiconfig": "^6.0.0",
+                "find-versions": "^3.2.0",
+                "opencollective-postinstall": "^2.0.2",
+                "pkg-dir": "^4.2.0",
+                "please-upgrade-node": "^3.2.0",
+                "slash": "^3.0.0",
+                "which-pm-runs": "^1.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -5905,8 +5910,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -5915,8 +5920,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -5925,7 +5930,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -5940,8 +5945,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "has-flag": {
@@ -5956,7 +5961,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -5965,7 +5970,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -5980,7 +5985,7 @@
                     "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
                     "dev": true,
                     "requires": {
-                        "find-up": "4.1.0"
+                        "find-up": "^4.0.0"
                     }
                 },
                 "supports-color": {
@@ -5989,7 +5994,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -5999,7 +6004,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "icss-utils": {
@@ -6008,7 +6013,7 @@
             "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
             "dev": true,
             "requires": {
-                "postcss": "7.0.32"
+                "postcss": "^7.0.14"
             }
         },
         "identity-obj-proxy": {
@@ -6017,7 +6022,7 @@
             "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
             "dev": true,
             "requires": {
-                "harmony-reflect": "1.6.1"
+                "harmony-reflect": "^1.4.6"
             }
         },
         "ieee754": {
@@ -6055,8 +6060,8 @@
             "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
             "dev": true,
             "requires": {
-                "parent-module": "1.0.1",
-                "resolve-from": "4.0.0"
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
             }
         },
         "import-local": {
@@ -6065,8 +6070,8 @@
             "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
             "dev": true,
             "requires": {
-                "pkg-dir": "4.2.0",
-                "resolve-cwd": "3.0.0"
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -6075,8 +6080,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "locate-path": {
@@ -6085,7 +6090,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -6094,7 +6099,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -6109,7 +6114,7 @@
                     "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
                     "dev": true,
                     "requires": {
-                        "find-up": "4.1.0"
+                        "find-up": "^4.0.0"
                     }
                 }
             }
@@ -6134,15 +6139,16 @@
         "infer-owner": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+            "dev": true
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -6162,9 +6168,9 @@
             "integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
             "dev": true,
             "requires": {
-                "es-abstract": "1.17.6",
-                "has": "1.0.3",
-                "side-channel": "1.0.2"
+                "es-abstract": "^1.17.0-next.1",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.2"
             }
         },
         "interpret": {
@@ -6190,7 +6196,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6199,7 +6205,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6217,7 +6223,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "binary-extensions": "2.1.0"
+                "binary-extensions": "^2.0.0"
             }
         },
         "is-boolean-object": {
@@ -6242,7 +6248,7 @@
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "dev": true,
             "requires": {
-                "ci-info": "2.0.0"
+                "ci-info": "^2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -6251,7 +6257,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6260,7 +6266,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6276,9 +6282,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -6325,7 +6331,7 @@
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-number": {
@@ -6356,7 +6362,7 @@
             "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
             "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
             "requires": {
-                "is-path-inside": "2.1.0"
+                "is-path-inside": "^2.1.0"
             }
         },
         "is-path-inside": {
@@ -6364,7 +6370,7 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
             "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.2"
             }
         },
         "is-plain-object": {
@@ -6373,7 +6379,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-potential-custom-element-name": {
@@ -6387,7 +6393,7 @@
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
             "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
             "requires": {
-                "has-symbols": "1.0.1"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-regexp": {
@@ -6419,7 +6425,7 @@
             "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
             "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "requires": {
-                "has-symbols": "1.0.1"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-typedarray": {
@@ -6437,7 +6443,8 @@
         "is-wsl": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
         },
         "isarray": {
             "version": "1.0.0",
@@ -6474,10 +6481,10 @@
             "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
             "dev": true,
             "requires": {
-                "@babel/core": "7.10.4",
-                "@istanbuljs/schema": "0.1.2",
-                "istanbul-lib-coverage": "3.0.0",
-                "semver": "6.3.0"
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
             },
             "dependencies": {
                 "semver": {
@@ -6494,9 +6501,9 @@
             "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "3.0.0",
-                "make-dir": "3.1.0",
-                "supports-color": "7.1.0"
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^3.0.0",
+                "supports-color": "^7.1.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -6511,7 +6518,7 @@
                     "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
                     "dev": true,
                     "requires": {
-                        "semver": "6.3.0"
+                        "semver": "^6.0.0"
                     }
                 },
                 "semver": {
@@ -6526,7 +6533,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6537,9 +6544,9 @@
             "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
             "dev": true,
             "requires": {
-                "debug": "4.1.1",
-                "istanbul-lib-coverage": "3.0.0",
-                "source-map": "0.6.1"
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
             }
         },
         "istanbul-reports": {
@@ -6548,8 +6555,8 @@
             "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
             "dev": true,
             "requires": {
-                "html-escaper": "2.0.2",
-                "istanbul-lib-report": "3.0.0"
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
             }
         },
         "jest": {
@@ -6558,9 +6565,9 @@
             "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
             "dev": true,
             "requires": {
-                "@jest/core": "26.1.0",
-                "import-local": "3.0.2",
-                "jest-cli": "26.1.0"
+                "@jest/core": "^26.1.0",
+                "import-local": "^3.0.2",
+                "jest-cli": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -6569,10 +6576,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -6581,8 +6588,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -6591,8 +6598,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -6601,7 +6608,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -6616,8 +6623,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "has-flag": {
@@ -6632,19 +6639,19 @@
                     "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "26.1.0",
-                        "@jest/test-result": "26.1.0",
-                        "@jest/types": "26.1.0",
-                        "chalk": "4.1.0",
-                        "exit": "0.1.2",
-                        "graceful-fs": "4.2.4",
-                        "import-local": "3.0.2",
-                        "is-ci": "2.0.0",
-                        "jest-config": "26.1.0",
-                        "jest-util": "26.1.0",
-                        "jest-validate": "26.1.0",
-                        "prompts": "2.3.2",
-                        "yargs": "15.3.1"
+                        "@jest/core": "^26.1.0",
+                        "@jest/test-result": "^26.1.0",
+                        "@jest/types": "^26.1.0",
+                        "chalk": "^4.0.0",
+                        "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "import-local": "^3.0.2",
+                        "is-ci": "^2.0.0",
+                        "jest-config": "^26.1.0",
+                        "jest-util": "^26.1.0",
+                        "jest-validate": "^26.1.0",
+                        "prompts": "^2.0.1",
+                        "yargs": "^15.3.1"
                     },
                     "dependencies": {
                         "yargs": {
@@ -6653,17 +6660,17 @@
                             "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
                             "dev": true,
                             "requires": {
-                                "cliui": "6.0.0",
-                                "decamelize": "1.2.0",
-                                "find-up": "4.1.0",
-                                "get-caller-file": "2.0.5",
-                                "require-directory": "2.1.1",
-                                "require-main-filename": "2.0.0",
-                                "set-blocking": "2.0.0",
-                                "string-width": "4.2.0",
-                                "which-module": "2.0.0",
-                                "y18n": "4.0.0",
-                                "yargs-parser": "18.1.3"
+                                "cliui": "^6.0.0",
+                                "decamelize": "^1.2.0",
+                                "find-up": "^4.1.0",
+                                "get-caller-file": "^2.0.1",
+                                "require-directory": "^2.1.1",
+                                "require-main-filename": "^2.0.0",
+                                "set-blocking": "^2.0.0",
+                                "string-width": "^4.2.0",
+                                "which-module": "^2.0.0",
+                                "y18n": "^4.0.0",
+                                "yargs-parser": "^18.1.1"
                             }
                         }
                     }
@@ -6674,7 +6681,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -6683,7 +6690,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -6698,7 +6705,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6709,9 +6716,9 @@
             "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "execa": "4.0.2",
-                "throat": "5.0.0"
+                "@jest/types": "^26.1.0",
+                "execa": "^4.0.0",
+                "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -6720,10 +6727,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -6732,8 +6739,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -6742,8 +6749,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -6752,7 +6759,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -6767,15 +6774,15 @@
                     "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "7.0.3",
-                        "get-stream": "5.1.0",
-                        "human-signals": "1.1.1",
-                        "is-stream": "2.0.0",
-                        "merge-stream": "2.0.0",
-                        "npm-run-path": "4.0.1",
-                        "onetime": "5.1.0",
-                        "signal-exit": "3.0.3",
-                        "strip-final-newline": "2.0.0"
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
                     }
                 },
                 "get-stream": {
@@ -6784,7 +6791,7 @@
                     "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
                     "dev": true,
                     "requires": {
-                        "pump": "3.0.0"
+                        "pump": "^3.0.0"
                     }
                 },
                 "has-flag": {
@@ -6805,7 +6812,7 @@
                     "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
                     "dev": true,
                     "requires": {
-                        "path-key": "3.1.1"
+                        "path-key": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -6814,7 +6821,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6825,24 +6832,24 @@
             "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
             "dev": true,
             "requires": {
-                "@babel/core": "7.10.4",
-                "@jest/test-sequencer": "26.1.0",
-                "@jest/types": "26.1.0",
-                "babel-jest": "26.1.0",
-                "chalk": "4.1.0",
-                "deepmerge": "4.2.2",
-                "glob": "7.1.6",
-                "graceful-fs": "4.2.4",
-                "jest-environment-jsdom": "26.1.0",
-                "jest-environment-node": "26.1.0",
-                "jest-get-type": "26.0.0",
-                "jest-jasmine2": "26.1.0",
-                "jest-regex-util": "26.0.0",
-                "jest-resolve": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-validate": "26.1.0",
-                "micromatch": "4.0.2",
-                "pretty-format": "26.1.0"
+                "@babel/core": "^7.1.0",
+                "@jest/test-sequencer": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "babel-jest": "^26.1.0",
+                "chalk": "^4.0.0",
+                "deepmerge": "^4.2.2",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.2.4",
+                "jest-environment-jsdom": "^26.1.0",
+                "jest-environment-node": "^26.1.0",
+                "jest-get-type": "^26.0.0",
+                "jest-jasmine2": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-validate": "^26.1.0",
+                "micromatch": "^4.0.2",
+                "pretty-format": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -6851,10 +6858,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -6863,8 +6870,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -6873,8 +6880,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -6883,7 +6890,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -6910,10 +6917,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -6922,7 +6929,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6933,10 +6940,10 @@
             "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
             "dev": true,
             "requires": {
-                "chalk": "3.0.0",
-                "diff-sequences": "25.2.6",
-                "jest-get-type": "25.2.6",
-                "pretty-format": "25.5.0"
+                "chalk": "^3.0.0",
+                "diff-sequences": "^25.2.6",
+                "jest-get-type": "^25.2.6",
+                "pretty-format": "^25.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -6945,8 +6952,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -6955,8 +6962,8 @@
                     "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -6965,7 +6972,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -6986,7 +6993,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -6997,7 +7004,7 @@
             "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
             "dev": true,
             "requires": {
-                "detect-newline": "3.1.0"
+                "detect-newline": "^3.0.0"
             }
         },
         "jest-each": {
@@ -7006,11 +7013,11 @@
             "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "jest-get-type": "26.0.0",
-                "jest-util": "26.1.0",
-                "pretty-format": "26.1.0"
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.0.0",
+                "jest-util": "^26.1.0",
+                "pretty-format": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7019,10 +7026,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7031,8 +7038,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7041,8 +7048,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7051,7 +7058,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7078,10 +7085,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -7090,7 +7097,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7101,12 +7108,12 @@
             "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "26.1.0",
-                "@jest/fake-timers": "26.1.0",
-                "@jest/types": "26.1.0",
-                "jest-mock": "26.1.0",
-                "jest-util": "26.1.0",
-                "jsdom": "16.2.2"
+                "@jest/environment": "^26.1.0",
+                "@jest/fake-timers": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "jest-mock": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jsdom": "^16.2.2"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7115,10 +7122,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7127,8 +7134,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7137,8 +7144,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7147,7 +7154,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7168,7 +7175,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7179,11 +7186,11 @@
             "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
             "dev": true,
             "requires": {
-                "@jest/environment": "26.1.0",
-                "@jest/fake-timers": "26.1.0",
-                "@jest/types": "26.1.0",
-                "jest-mock": "26.1.0",
-                "jest-util": "26.1.0"
+                "@jest/environment": "^26.1.0",
+                "@jest/fake-timers": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "jest-mock": "^26.1.0",
+                "jest-util": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7192,10 +7199,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7204,8 +7211,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7214,8 +7221,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7224,7 +7231,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7245,7 +7252,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7262,19 +7269,19 @@
             "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "@types/graceful-fs": "4.1.3",
-                "anymatch": "3.1.1",
-                "fb-watchman": "2.0.1",
-                "fsevents": "2.1.3",
-                "graceful-fs": "4.2.4",
-                "jest-serializer": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-worker": "26.1.0",
-                "micromatch": "4.0.2",
-                "sane": "4.1.0",
-                "walker": "1.0.7",
-                "which": "2.0.2"
+                "@jest/types": "^26.1.0",
+                "@types/graceful-fs": "^4.1.2",
+                "anymatch": "^3.0.3",
+                "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-serializer": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-worker": "^26.1.0",
+                "micromatch": "^4.0.2",
+                "sane": "^4.0.3",
+                "walker": "^1.0.7",
+                "which": "^2.0.2"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7283,10 +7290,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7295,8 +7302,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7305,8 +7312,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7315,7 +7322,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7336,7 +7343,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7347,23 +7354,23 @@
             "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "7.10.4",
-                "@jest/environment": "26.1.0",
-                "@jest/source-map": "26.1.0",
-                "@jest/test-result": "26.1.0",
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "co": "4.6.0",
-                "expect": "26.1.0",
-                "is-generator-fn": "2.1.0",
-                "jest-each": "26.1.0",
-                "jest-matcher-utils": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-runtime": "26.1.0",
-                "jest-snapshot": "26.1.0",
-                "jest-util": "26.1.0",
-                "pretty-format": "26.1.0",
-                "throat": "5.0.0"
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.1.0",
+                "@jest/source-map": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "expect": "^26.1.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.1.0",
+                "jest-matcher-utils": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-runtime": "^26.1.0",
+                "jest-snapshot": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "pretty-format": "^26.1.0",
+                "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7372,10 +7379,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7384,8 +7391,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7394,8 +7401,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7404,7 +7411,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7425,10 +7432,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -7437,7 +7444,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7448,7 +7455,7 @@
             "integrity": "sha1-iNYAbsE/gt9AxHiCyGQJic3LFDQ=",
             "dev": true,
             "requires": {
-                "xml": "1.0.1"
+                "xml": "^1.0.1"
             }
         },
         "jest-leak-detector": {
@@ -7457,8 +7464,8 @@
             "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
             "dev": true,
             "requires": {
-                "jest-get-type": "26.0.0",
-                "pretty-format": "26.1.0"
+                "jest-get-type": "^26.0.0",
+                "pretty-format": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7467,10 +7474,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7479,8 +7486,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7489,8 +7496,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7499,7 +7506,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7526,10 +7533,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -7538,7 +7545,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7549,10 +7556,10 @@
             "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
             "dev": true,
             "requires": {
-                "chalk": "4.1.0",
-                "jest-diff": "26.1.0",
-                "jest-get-type": "26.0.0",
-                "pretty-format": "26.1.0"
+                "chalk": "^4.0.0",
+                "jest-diff": "^26.1.0",
+                "jest-get-type": "^26.0.0",
+                "pretty-format": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7561,10 +7568,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7573,8 +7580,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7583,8 +7590,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7593,7 +7600,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7620,10 +7627,10 @@
                     "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "4.1.0",
-                        "diff-sequences": "26.0.0",
-                        "jest-get-type": "26.0.0",
-                        "pretty-format": "26.1.0"
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.1.0"
                     }
                 },
                 "jest-get-type": {
@@ -7638,10 +7645,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -7650,7 +7657,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7661,14 +7668,14 @@
             "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.10.4",
-                "@jest/types": "26.1.0",
-                "@types/stack-utils": "1.0.1",
-                "chalk": "4.1.0",
-                "graceful-fs": "4.2.4",
-                "micromatch": "4.0.2",
-                "slash": "3.0.0",
-                "stack-utils": "2.0.2"
+                "@babel/code-frame": "^7.0.0",
+                "@jest/types": "^26.1.0",
+                "@types/stack-utils": "^1.0.1",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "micromatch": "^4.0.2",
+                "slash": "^3.0.0",
+                "stack-utils": "^2.0.2"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7677,10 +7684,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7689,8 +7696,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7699,8 +7706,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7709,7 +7716,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7730,7 +7737,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7741,7 +7748,7 @@
             "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0"
+                "@jest/types": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7750,10 +7757,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7762,8 +7769,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7772,8 +7779,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7782,7 +7789,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7803,7 +7810,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7826,14 +7833,14 @@
             "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "graceful-fs": "4.2.4",
-                "jest-pnp-resolver": "1.2.2",
-                "jest-util": "26.1.0",
-                "read-pkg-up": "7.0.1",
-                "resolve": "1.17.0",
-                "slash": "3.0.0"
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "jest-pnp-resolver": "^1.2.1",
+                "jest-util": "^26.1.0",
+                "read-pkg-up": "^7.0.1",
+                "resolve": "^1.17.0",
+                "slash": "^3.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7842,10 +7849,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -7854,8 +7861,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -7864,8 +7871,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -7874,7 +7881,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -7889,8 +7896,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "has-flag": {
@@ -7905,7 +7912,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -7914,7 +7921,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "parse-json": {
@@ -7923,10 +7930,10 @@
                     "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "7.10.4",
-                        "error-ex": "1.3.2",
-                        "json-parse-better-errors": "1.0.2",
-                        "lines-and-columns": "1.1.6"
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
                     }
                 },
                 "path-exists": {
@@ -7941,10 +7948,10 @@
                     "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
                     "dev": true,
                     "requires": {
-                        "@types/normalize-package-data": "2.4.0",
-                        "normalize-package-data": "2.5.0",
-                        "parse-json": "5.0.0",
-                        "type-fest": "0.6.0"
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
                     },
                     "dependencies": {
                         "type-fest": {
@@ -7961,9 +7968,9 @@
                     "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
                     "dev": true,
                     "requires": {
-                        "find-up": "4.1.0",
-                        "read-pkg": "5.2.0",
-                        "type-fest": "0.8.1"
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
                     }
                 },
                 "supports-color": {
@@ -7972,7 +7979,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -7983,9 +7990,9 @@
             "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "jest-regex-util": "26.0.0",
-                "jest-snapshot": "26.1.0"
+                "@jest/types": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-snapshot": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -7994,10 +8001,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8006,8 +8013,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8016,8 +8023,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8026,7 +8033,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8047,7 +8054,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8058,25 +8065,25 @@
             "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
             "dev": true,
             "requires": {
-                "@jest/console": "26.1.0",
-                "@jest/environment": "26.1.0",
-                "@jest/test-result": "26.1.0",
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "exit": "0.1.2",
-                "graceful-fs": "4.2.4",
-                "jest-config": "26.1.0",
-                "jest-docblock": "26.0.0",
-                "jest-haste-map": "26.1.0",
-                "jest-jasmine2": "26.1.0",
-                "jest-leak-detector": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-resolve": "26.1.0",
-                "jest-runtime": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-worker": "26.1.0",
-                "source-map-support": "0.5.19",
-                "throat": "5.0.0"
+                "@jest/console": "^26.1.0",
+                "@jest/environment": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "exit": "^0.1.2",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.1.0",
+                "jest-docblock": "^26.0.0",
+                "jest-haste-map": "^26.1.0",
+                "jest-jasmine2": "^26.1.0",
+                "jest-leak-detector": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-resolve": "^26.1.0",
+                "jest-runtime": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-worker": "^26.1.0",
+                "source-map-support": "^0.5.6",
+                "throat": "^5.0.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8085,10 +8092,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8097,8 +8104,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8107,8 +8114,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8117,7 +8124,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8138,7 +8145,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8149,32 +8156,32 @@
             "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
             "dev": true,
             "requires": {
-                "@jest/console": "26.1.0",
-                "@jest/environment": "26.1.0",
-                "@jest/fake-timers": "26.1.0",
-                "@jest/globals": "26.1.0",
-                "@jest/source-map": "26.1.0",
-                "@jest/test-result": "26.1.0",
-                "@jest/transform": "26.1.0",
-                "@jest/types": "26.1.0",
-                "@types/yargs": "15.0.5",
-                "chalk": "4.1.0",
-                "collect-v8-coverage": "1.0.1",
-                "exit": "0.1.2",
-                "glob": "7.1.6",
-                "graceful-fs": "4.2.4",
-                "jest-config": "26.1.0",
-                "jest-haste-map": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-mock": "26.1.0",
-                "jest-regex-util": "26.0.0",
-                "jest-resolve": "26.1.0",
-                "jest-snapshot": "26.1.0",
-                "jest-util": "26.1.0",
-                "jest-validate": "26.1.0",
-                "slash": "3.0.0",
-                "strip-bom": "4.0.0",
-                "yargs": "15.3.1"
+                "@jest/console": "^26.1.0",
+                "@jest/environment": "^26.1.0",
+                "@jest/fake-timers": "^26.1.0",
+                "@jest/globals": "^26.1.0",
+                "@jest/source-map": "^26.1.0",
+                "@jest/test-result": "^26.1.0",
+                "@jest/transform": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "@types/yargs": "^15.0.0",
+                "chalk": "^4.0.0",
+                "collect-v8-coverage": "^1.0.0",
+                "exit": "^0.1.2",
+                "glob": "^7.1.3",
+                "graceful-fs": "^4.2.4",
+                "jest-config": "^26.1.0",
+                "jest-haste-map": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-mock": "^26.1.0",
+                "jest-regex-util": "^26.0.0",
+                "jest-resolve": "^26.1.0",
+                "jest-snapshot": "^26.1.0",
+                "jest-util": "^26.1.0",
+                "jest-validate": "^26.1.0",
+                "slash": "^3.0.0",
+                "strip-bom": "^4.0.0",
+                "yargs": "^15.3.1"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8183,10 +8190,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8195,8 +8202,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8205,8 +8212,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8215,7 +8222,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8230,8 +8237,8 @@
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "has-flag": {
@@ -8246,7 +8253,7 @@
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -8255,7 +8262,7 @@
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -8276,7 +8283,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 },
                 "yargs": {
@@ -8285,17 +8292,17 @@
                     "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
                     "dev": true,
                     "requires": {
-                        "cliui": "6.0.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "4.1.0",
-                        "get-caller-file": "2.0.5",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "2.0.0",
-                        "set-blocking": "2.0.0",
-                        "string-width": "4.2.0",
-                        "which-module": "2.0.0",
-                        "y18n": "4.0.0",
-                        "yargs-parser": "18.1.3"
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.1"
                     }
                 }
             }
@@ -8306,7 +8313,7 @@
             "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.2.4"
+                "graceful-fs": "^4.2.4"
             }
         },
         "jest-snapshot": {
@@ -8315,21 +8322,21 @@
             "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
             "dev": true,
             "requires": {
-                "@babel/types": "7.10.4",
-                "@jest/types": "26.1.0",
-                "@types/prettier": "2.0.1",
-                "chalk": "4.1.0",
-                "expect": "26.1.0",
-                "graceful-fs": "4.2.4",
-                "jest-diff": "26.1.0",
-                "jest-get-type": "26.0.0",
-                "jest-haste-map": "26.1.0",
-                "jest-matcher-utils": "26.1.0",
-                "jest-message-util": "26.1.0",
-                "jest-resolve": "26.1.0",
-                "natural-compare": "1.4.0",
-                "pretty-format": "26.1.0",
-                "semver": "7.3.2"
+                "@babel/types": "^7.0.0",
+                "@jest/types": "^26.1.0",
+                "@types/prettier": "^2.0.0",
+                "chalk": "^4.0.0",
+                "expect": "^26.1.0",
+                "graceful-fs": "^4.2.4",
+                "jest-diff": "^26.1.0",
+                "jest-get-type": "^26.0.0",
+                "jest-haste-map": "^26.1.0",
+                "jest-matcher-utils": "^26.1.0",
+                "jest-message-util": "^26.1.0",
+                "jest-resolve": "^26.1.0",
+                "natural-compare": "^1.4.0",
+                "pretty-format": "^26.1.0",
+                "semver": "^7.3.2"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8338,10 +8345,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8350,8 +8357,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8360,8 +8367,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8370,7 +8377,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8397,10 +8404,10 @@
                     "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "4.1.0",
-                        "diff-sequences": "26.0.0",
-                        "jest-get-type": "26.0.0",
-                        "pretty-format": "26.1.0"
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.0.0",
+                        "jest-get-type": "^26.0.0",
+                        "pretty-format": "^26.1.0"
                     }
                 },
                 "jest-get-type": {
@@ -8415,10 +8422,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "semver": {
@@ -8433,7 +8440,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8444,11 +8451,11 @@
             "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "chalk": "4.1.0",
-                "graceful-fs": "4.2.4",
-                "is-ci": "2.0.0",
-                "micromatch": "4.0.2"
+                "@jest/types": "^26.1.0",
+                "chalk": "^4.0.0",
+                "graceful-fs": "^4.2.4",
+                "is-ci": "^2.0.0",
+                "micromatch": "^4.0.2"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8457,10 +8464,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8469,8 +8476,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8479,8 +8486,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8489,7 +8496,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8510,7 +8517,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8521,12 +8528,12 @@
             "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
             "dev": true,
             "requires": {
-                "@jest/types": "26.1.0",
-                "camelcase": "6.0.0",
-                "chalk": "4.1.0",
-                "jest-get-type": "26.0.0",
-                "leven": "3.1.0",
-                "pretty-format": "26.1.0"
+                "@jest/types": "^26.1.0",
+                "camelcase": "^6.0.0",
+                "chalk": "^4.0.0",
+                "jest-get-type": "^26.0.0",
+                "leven": "^3.1.0",
+                "pretty-format": "^26.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8535,10 +8542,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8547,8 +8554,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "camelcase": {
@@ -8563,8 +8570,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8573,7 +8580,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8600,10 +8607,10 @@
                     "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "26.1.0",
-                        "ansi-regex": "5.0.0",
-                        "ansi-styles": "4.2.1",
-                        "react-is": "16.13.1"
+                        "@jest/types": "^26.1.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
                     }
                 },
                 "supports-color": {
@@ -8612,7 +8619,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8623,12 +8630,12 @@
             "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "26.1.0",
-                "@jest/types": "26.1.0",
-                "ansi-escapes": "4.3.1",
-                "chalk": "4.1.0",
-                "jest-util": "26.1.0",
-                "string-length": "4.0.1"
+                "@jest/test-result": "^26.1.0",
+                "@jest/types": "^26.1.0",
+                "ansi-escapes": "^4.2.1",
+                "chalk": "^4.0.0",
+                "jest-util": "^26.1.0",
+                "string-length": "^4.0.1"
             },
             "dependencies": {
                 "@jest/types": {
@@ -8637,10 +8644,10 @@
                     "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "2.0.3",
-                        "@types/istanbul-reports": "1.1.2",
-                        "@types/yargs": "15.0.5",
-                        "chalk": "4.1.0"
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^1.1.1",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
                     }
                 },
                 "ansi-styles": {
@@ -8649,8 +8656,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -8659,8 +8666,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -8669,7 +8676,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -8690,7 +8697,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8701,8 +8708,8 @@
             "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
             "dev": true,
             "requires": {
-                "merge-stream": "2.0.0",
-                "supports-color": "7.1.0"
+                "merge-stream": "^2.0.0",
+                "supports-color": "^7.0.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -8717,7 +8724,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -8732,8 +8739,8 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
             "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -8748,32 +8755,32 @@
             "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
             "dev": true,
             "requires": {
-                "abab": "2.0.3",
-                "acorn": "7.3.1",
-                "acorn-globals": "6.0.0",
-                "cssom": "0.4.4",
-                "cssstyle": "2.3.0",
-                "data-urls": "2.0.0",
-                "decimal.js": "10.2.0",
-                "domexception": "2.0.1",
-                "escodegen": "1.14.3",
-                "html-encoding-sniffer": "2.0.1",
-                "is-potential-custom-element-name": "1.0.0",
-                "nwsapi": "2.2.0",
+                "abab": "^2.0.3",
+                "acorn": "^7.1.1",
+                "acorn-globals": "^6.0.0",
+                "cssom": "^0.4.4",
+                "cssstyle": "^2.2.0",
+                "data-urls": "^2.0.0",
+                "decimal.js": "^10.2.0",
+                "domexception": "^2.0.1",
+                "escodegen": "^1.14.1",
+                "html-encoding-sniffer": "^2.0.1",
+                "is-potential-custom-element-name": "^1.0.0",
+                "nwsapi": "^2.2.0",
                 "parse5": "5.1.1",
-                "request": "2.88.2",
-                "request-promise-native": "1.0.8",
-                "saxes": "5.0.1",
-                "symbol-tree": "3.2.4",
-                "tough-cookie": "3.0.1",
-                "w3c-hr-time": "1.0.2",
-                "w3c-xmlserializer": "2.0.0",
-                "webidl-conversions": "6.1.0",
-                "whatwg-encoding": "1.0.5",
-                "whatwg-mimetype": "2.3.0",
-                "whatwg-url": "8.1.0",
-                "ws": "7.3.0",
-                "xml-name-validator": "3.0.0"
+                "request": "^2.88.2",
+                "request-promise-native": "^1.0.8",
+                "saxes": "^5.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^3.0.1",
+                "w3c-hr-time": "^1.0.2",
+                "w3c-xmlserializer": "^2.0.0",
+                "webidl-conversions": "^6.0.0",
+                "whatwg-encoding": "^1.0.5",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0",
+                "ws": "^7.2.3",
+                "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
                 "parse5": {
@@ -8788,9 +8795,9 @@
                     "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
                     "dev": true,
                     "requires": {
-                        "ip-regex": "2.1.0",
-                        "psl": "1.8.0",
-                        "punycode": "2.1.1"
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
                     }
                 },
                 "ws": {
@@ -8840,7 +8847,7 @@
             "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
             "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
             "requires": {
-                "minimist": "1.2.5"
+                "minimist": "^1.2.0"
             }
         },
         "jsonfile": {
@@ -8848,7 +8855,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "requires": {
-                "graceful-fs": "4.2.4"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsprim": {
@@ -8869,8 +8876,8 @@
             "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
             "dev": true,
             "requires": {
-                "array-includes": "3.1.1",
-                "object.assign": "4.1.0"
+                "array-includes": "^3.1.1",
+                "object.assign": "^4.1.0"
             }
         },
         "kind-of": {
@@ -8897,7 +8904,7 @@
             "integrity": "sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=",
             "dev": true,
             "requires": {
-                "language-subtag-registry": "0.3.20"
+                "language-subtag-registry": "~0.3.2"
             }
         },
         "less": {
@@ -8906,16 +8913,16 @@
             "integrity": "sha512-VkZiTDdtNEzXA3LgjQiC3D7/ejleBPFVvq+aRI9mIj+Zhmif5TvFPM244bT4rzkvOCvJ9q4zAztok1M7Nygagw==",
             "dev": true,
             "requires": {
-                "clone": "2.1.2",
-                "errno": "0.1.7",
-                "graceful-fs": "4.2.4",
-                "image-size": "0.5.5",
-                "make-dir": "2.1.0",
-                "mime": "1.6.0",
-                "promise": "7.3.1",
-                "request": "2.88.2",
-                "source-map": "0.6.1",
-                "tslib": "1.13.0"
+                "clone": "^2.1.2",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "make-dir": "^2.1.0",
+                "mime": "^1.4.1",
+                "promise": "^7.1.1",
+                "request": "^2.83.0",
+                "source-map": "~0.6.0",
+                "tslib": "^1.10.0"
             }
         },
         "less-loader": {
@@ -8924,10 +8931,10 @@
             "integrity": "sha512-gzG3gQd3da+E06yasOB1zR6klEEyfXp/kYZ+5Su89AVE656klCilD58QFYALqky6yL1d/ZSEKgVjkwH3meIpIQ==",
             "dev": true,
             "requires": {
-                "clone": "2.1.2",
-                "less": "3.11.3",
-                "loader-utils": "2.0.0",
-                "schema-utils": "2.7.0"
+                "clone": "^2.1.2",
+                "less": "^3.11.3",
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^2.7.0"
             },
             "dependencies": {
                 "json5": {
@@ -8936,7 +8943,7 @@
                     "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.5"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "loader-utils": {
@@ -8945,9 +8952,9 @@
                     "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
                     "dev": true,
                     "requires": {
-                        "big.js": "5.2.2",
-                        "emojis-list": "3.0.0",
-                        "json5": "2.1.3"
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
                     }
                 },
                 "schema-utils": {
@@ -8956,9 +8963,9 @@
                     "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
                     "dev": true,
                     "requires": {
-                        "@types/json-schema": "7.0.5",
-                        "ajv": "6.12.2",
-                        "ajv-keywords": "3.5.0"
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
                     }
                 }
             }
@@ -8975,8 +8982,8 @@
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.2.1",
-                "type-check": "0.4.0"
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
             }
         },
         "lie": {
@@ -8984,7 +8991,7 @@
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
             "requires": {
-                "immediate": "3.0.6"
+                "immediate": "~3.0.5"
             }
         },
         "lines-and-columns": {
@@ -8999,21 +9006,21 @@
             "integrity": "sha512-LRRrSogzbixYaZItE2APaS4l2eJMjjf5MbclRZpLJtcQJShcvUzKXsNeZgsLIZ0H0+fg2tL4B59fU9wHIHtFIA==",
             "dev": true,
             "requires": {
-                "chalk": "4.1.0",
+                "chalk": "^4.0.0",
                 "cli-truncate": "2.1.0",
-                "commander": "5.1.0",
-                "cosmiconfig": "6.0.0",
-                "debug": "4.1.1",
-                "dedent": "0.7.0",
-                "enquirer": "2.3.5",
-                "execa": "4.0.2",
-                "listr2": "2.1.8",
-                "log-symbols": "4.0.0",
-                "micromatch": "4.0.2",
-                "normalize-path": "3.0.0",
-                "please-upgrade-node": "3.2.0",
+                "commander": "^5.1.0",
+                "cosmiconfig": "^6.0.0",
+                "debug": "^4.1.1",
+                "dedent": "^0.7.0",
+                "enquirer": "^2.3.5",
+                "execa": "^4.0.1",
+                "listr2": "^2.1.0",
+                "log-symbols": "^4.0.0",
+                "micromatch": "^4.0.2",
+                "normalize-path": "^3.0.0",
+                "please-upgrade-node": "^3.2.0",
                 "string-argv": "0.3.1",
-                "stringify-object": "3.3.0"
+                "stringify-object": "^3.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9022,8 +9029,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -9032,8 +9039,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -9042,7 +9049,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -9063,15 +9070,15 @@
                     "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "7.0.3",
-                        "get-stream": "5.1.0",
-                        "human-signals": "1.1.1",
-                        "is-stream": "2.0.0",
-                        "merge-stream": "2.0.0",
-                        "npm-run-path": "4.0.1",
-                        "onetime": "5.1.0",
-                        "signal-exit": "3.0.3",
-                        "strip-final-newline": "2.0.0"
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
                     }
                 },
                 "get-stream": {
@@ -9080,7 +9087,7 @@
                     "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
                     "dev": true,
                     "requires": {
-                        "pump": "3.0.0"
+                        "pump": "^3.0.0"
                     }
                 },
                 "has-flag": {
@@ -9101,7 +9108,7 @@
                     "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
                     "dev": true,
                     "requires": {
-                        "path-key": "3.1.1"
+                        "path-key": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -9110,7 +9117,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -9121,14 +9128,14 @@
             "integrity": "sha512-Op+hheiChfAphkJ5qUxZtHgyjlX9iNnAeFS/S134xw7mVSg0YVrQo1IY4/K+ElY6XgOPg2Ij4z07urUXR+YEew==",
             "dev": true,
             "requires": {
-                "chalk": "4.1.0",
-                "cli-truncate": "2.1.0",
-                "figures": "3.2.0",
-                "indent-string": "4.0.0",
-                "log-update": "4.0.0",
-                "p-map": "4.0.0",
-                "rxjs": "6.5.5",
-                "through": "2.3.8"
+                "chalk": "^4.0.0",
+                "cli-truncate": "^2.1.0",
+                "figures": "^3.2.0",
+                "indent-string": "^4.0.0",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rxjs": "^6.5.5",
+                "through": "^2.3.8"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9137,8 +9144,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -9147,8 +9154,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -9157,7 +9164,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -9178,7 +9185,7 @@
                     "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
                     "dev": true,
                     "requires": {
-                        "aggregate-error": "3.0.1"
+                        "aggregate-error": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -9187,7 +9194,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -9198,10 +9205,10 @@
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.2.4",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -9223,9 +9230,9 @@
             "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
             "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
             "requires": {
-                "big.js": "5.2.2",
-                "emojis-list": "3.0.0",
-                "json5": "1.0.1"
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^1.0.1"
             }
         },
         "localforage": {
@@ -9240,9 +9247,10 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
             "requires": {
-                "p-locate": "3.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -9296,7 +9304,7 @@
             "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
             "dev": true,
             "requires": {
-                "chalk": "4.1.0"
+                "chalk": "^4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9305,8 +9313,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "chalk": {
@@ -9315,8 +9323,8 @@
                     "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "supports-color": "7.1.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
                 "color-convert": {
@@ -9325,7 +9333,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -9346,7 +9354,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -9357,10 +9365,10 @@
             "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "4.3.1",
-                "cli-cursor": "3.1.0",
-                "slice-ansi": "4.0.0",
-                "wrap-ansi": "6.2.0"
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9369,8 +9377,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "astral-regex": {
@@ -9385,7 +9393,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -9400,9 +9408,9 @@
                     "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "4.2.1",
-                        "astral-regex": "2.0.0",
-                        "is-fullwidth-code-point": "3.0.0"
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
                     }
                 }
             }
@@ -9412,15 +9420,16 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "requires": {
-                "js-tokens": "4.0.0"
+                "js-tokens": "^3.0.0 || ^4.0.0"
             }
         },
         "lru-cache": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
             "requires": {
-                "yallist": "3.1.1"
+                "yallist": "^3.0.2"
             }
         },
         "lunr": {
@@ -9433,9 +9442,10 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
             "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
             "requires": {
-                "pify": "4.0.1",
-                "semver": "5.7.1"
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
             }
         },
         "make-error": {
@@ -9450,7 +9460,7 @@
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
-                "tmpl": "1.0.4"
+                "tmpl": "1.0.x"
             }
         },
         "map-cache": {
@@ -9465,7 +9475,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "marked": {
@@ -9480,9 +9490,9 @@
             "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
             "dev": true,
             "requires": {
-                "hash-base": "3.1.0",
-                "inherits": "2.0.4",
-                "safe-buffer": "5.1.2"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
             }
         },
         "mdn-data": {
@@ -9501,8 +9511,8 @@
             "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "readable-stream": "2.3.7"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             }
         },
         "merge-descriptors": {
@@ -9527,8 +9537,8 @@
             "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
             "dev": true,
             "requires": {
-                "braces": "3.0.2",
-                "picomatch": "2.2.2"
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
             }
         },
         "miller-rabin": {
@@ -9537,8 +9547,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             },
             "dependencies": {
                 "bn.js": {
@@ -9590,7 +9600,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -9602,17 +9612,18 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
             "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+            "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "duplexify": "3.7.1",
-                "end-of-stream": "1.4.4",
-                "flush-write-stream": "1.1.1",
-                "from2": "2.3.0",
-                "parallel-transform": "1.2.0",
-                "pump": "3.0.0",
-                "pumpify": "1.5.1",
-                "stream-each": "1.2.3",
-                "through2": "2.0.5"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^3.0.0",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             }
         },
         "mixin-deep": {
@@ -9621,8 +9632,8 @@
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -9631,7 +9642,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -9641,7 +9652,7 @@
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
             "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "1.2.5"
+                "minimist": "^1.2.5"
             }
         },
         "moment": {
@@ -9661,12 +9672,12 @@
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.5",
-                "rimraf": "2.7.1",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -9679,9 +9690,9 @@
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "requires": {
-                "any-promise": "1.3.0",
-                "object-assign": "4.1.1",
-                "thenify-all": "1.6.0"
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
             }
         },
         "nanomatch": {
@@ -9690,17 +9701,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.3",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "natural-compare": {
@@ -9715,11 +9726,11 @@
             "integrity": "sha512-oqj3m4oqwKsN77pETa9IPvxHHHLW68KrDc2KYoWMUOhDlrNUo7finubwffQMBRnwNCOXc4kRxCZO0Rvx4L6Zrw==",
             "dev": true,
             "requires": {
-                "commander": "2.20.3",
-                "moo": "0.5.1",
-                "railroad-diagrams": "1.0.0",
+                "commander": "^2.19.0",
+                "moo": "^0.5.0",
+                "railroad-diagrams": "^1.0.0",
                 "randexp": "0.4.6",
-                "semver": "5.7.1"
+                "semver": "^5.4.1"
             }
         },
         "negotiator": {
@@ -9751,29 +9762,29 @@
             "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
             "dev": true,
             "requires": {
-                "assert": "1.5.0",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.2",
-                "console-browserify": "1.2.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "3.1.0",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^3.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.1",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.7",
-                "stream-browserify": "2.0.2",
-                "stream-http": "2.8.3",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.11",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.11.1",
-                "vm-browserify": "1.1.2"
+                "url": "^0.11.0",
+                "util": "^0.11.0",
+                "vm-browserify": "^1.0.1"
             },
             "dependencies": {
                 "punycode": {
@@ -9797,12 +9808,12 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "growly": "1.3.0",
-                "is-wsl": "2.2.0",
-                "semver": "7.3.2",
-                "shellwords": "0.1.1",
-                "uuid": "7.0.3",
-                "which": "2.0.2"
+                "growly": "^1.3.0",
+                "is-wsl": "^2.1.1",
+                "semver": "^7.2.1",
+                "shellwords": "^0.1.1",
+                "uuid": "^7.0.3",
+                "which": "^2.0.2"
             },
             "dependencies": {
                 "is-wsl": {
@@ -9812,7 +9823,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-docker": "2.0.0"
+                        "is-docker": "^2.0.0"
                     }
                 },
                 "semver": {
@@ -9830,10 +9841,10 @@
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.8.8",
-                "resolve": "1.17.0",
-                "semver": "5.7.1",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -9848,7 +9859,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             },
             "dependencies": {
                 "path-key": {
@@ -9864,7 +9875,7 @@
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
             "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "nwsapi": {
@@ -9890,9 +9901,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -9901,7 +9912,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -9910,7 +9921,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -9932,8 +9943,8 @@
             "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "object-keys": {
@@ -9947,7 +9958,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -9955,10 +9966,10 @@
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.1",
-                "object-keys": "1.1.1"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.entries": {
@@ -9967,9 +9978,9 @@
             "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "has": "1.0.3"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5",
+                "has": "^1.0.3"
             }
         },
         "object.fromentries": {
@@ -9978,10 +9989,10 @@
             "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "function-bind": "1.1.1",
-                "has": "1.0.3"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "object.getownpropertydescriptors": {
@@ -9989,8 +10000,8 @@
             "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
             "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "object.pick": {
@@ -9999,7 +10010,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.values": {
@@ -10007,10 +10018,10 @@
             "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
             "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "function-bind": "1.1.1",
-                "has": "1.0.3"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "on-finished": {
@@ -10026,7 +10037,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -10035,7 +10046,7 @@
             "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
             "dev": true,
             "requires": {
-                "mimic-fn": "2.1.0"
+                "mimic-fn": "^2.1.0"
             }
         },
         "opencollective-postinstall": {
@@ -10055,12 +10066,12 @@
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.4.1",
-                "prelude-ls": "1.2.1",
-                "type-check": "0.4.0",
-                "word-wrap": "1.2.3"
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
             }
         },
         "os-browserify": {
@@ -10086,15 +10097,16 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "requires": {
-                "p-try": "2.2.0"
+                "p-try": "^2.0.0"
             }
         },
         "p-locate": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
             "requires": {
-                "p-limit": "2.3.0"
+                "p-limit": "^2.0.0"
             }
         },
         "p-map": {
@@ -10118,9 +10130,9 @@
             "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
             "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
             "requires": {
-                "cyclist": "1.0.1",
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7"
+                "cyclist": "^1.0.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             }
         },
         "parent-module": {
@@ -10129,7 +10141,7 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
-                "callsites": "3.1.0"
+                "callsites": "^3.0.0"
             }
         },
         "parse-asn1": {
@@ -10138,12 +10150,12 @@
             "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.1.1",
-                "safe-buffer": "5.1.2"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
             }
         },
         "parse-json": {
@@ -10152,7 +10164,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -10167,7 +10179,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "14.0.14"
+                "@types/node": "*"
             }
         },
         "parseurl": {
@@ -10231,7 +10243,7 @@
             "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
             "dev": true,
             "requires": {
-                "pify": "2.3.0"
+                "pify": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -10248,11 +10260,11 @@
             "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "performance-now": {
@@ -10282,7 +10294,7 @@
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pirates": {
@@ -10291,15 +10303,16 @@
             "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
             "dev": true,
             "requires": {
-                "node-modules-regexp": "1.0.0"
+                "node-modules-regexp": "^1.0.0"
             }
         },
         "pkg-dir": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+            "dev": true,
             "requires": {
-                "find-up": "3.0.0"
+                "find-up": "^3.0.0"
             }
         },
         "please-upgrade-node": {
@@ -10308,7 +10321,7 @@
             "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
             "dev": true,
             "requires": {
-                "semver-compare": "1.0.0"
+                "semver-compare": "^1.0.0"
             }
         },
         "posix-character-classes": {
@@ -10323,9 +10336,9 @@
             "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.2",
-                "source-map": "0.6.1",
-                "supports-color": "6.1.0"
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -10334,7 +10347,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -10345,7 +10358,7 @@
             "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
             "dev": true,
             "requires": {
-                "postcss": "7.0.32"
+                "postcss": "^7.0.5"
             }
         },
         "postcss-modules-local-by-default": {
@@ -10354,10 +10367,10 @@
             "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
             "dev": true,
             "requires": {
-                "icss-utils": "4.1.1",
-                "postcss": "7.0.32",
-                "postcss-selector-parser": "6.0.2",
-                "postcss-value-parser": "4.1.0"
+                "icss-utils": "^4.1.1",
+                "postcss": "^7.0.16",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.0.0"
             }
         },
         "postcss-modules-scope": {
@@ -10366,8 +10379,8 @@
             "integrity": "sha512-YyEgsTMRpNd+HmyC7H/mh3y+MeFWevy7V1evVhJWewmMbjDHIbZbOXICC2y+m1xI1UVfIT1HMW/O04Hxyu9oXQ==",
             "dev": true,
             "requires": {
-                "postcss": "7.0.32",
-                "postcss-selector-parser": "6.0.2"
+                "postcss": "^7.0.6",
+                "postcss-selector-parser": "^6.0.0"
             }
         },
         "postcss-modules-values": {
@@ -10376,8 +10389,8 @@
             "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
             "dev": true,
             "requires": {
-                "icss-utils": "4.1.1",
-                "postcss": "7.0.32"
+                "icss-utils": "^4.0.0",
+                "postcss": "^7.0.6"
             }
         },
         "postcss-selector-parser": {
@@ -10386,9 +10399,9 @@
             "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
             "dev": true,
             "requires": {
-                "cssesc": "3.0.0",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "cssesc": "^3.0.0",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-value-parser": {
@@ -10409,10 +10422,10 @@
             "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "25.5.0",
-                "ansi-regex": "5.0.0",
-                "ansi-styles": "4.2.1",
-                "react-is": "16.13.1"
+                "@jest/types": "^25.5.0",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^4.0.0",
+                "react-is": "^16.12.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10421,8 +10434,8 @@
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "dev": true,
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "color-convert": {
@@ -10431,7 +10444,7 @@
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -10466,7 +10479,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "promise-inflight": {
@@ -10480,8 +10493,8 @@
             "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
             "dev": true,
             "requires": {
-                "kleur": "3.0.3",
-                "sisteransi": "1.0.5"
+                "kleur": "^3.0.3",
+                "sisteransi": "^1.0.4"
             }
         },
         "prop-types": {
@@ -10489,9 +10502,9 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
             "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "react-is": "16.13.1"
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
             }
         },
         "prop-types-exact": {
@@ -10500,9 +10513,9 @@
             "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
             "dev": true,
             "requires": {
-                "has": "1.0.3",
-                "object.assign": "4.1.0",
-                "reflect.ownkeys": "0.2.0"
+                "has": "^1.0.3",
+                "object.assign": "^4.1.0",
+                "reflect.ownkeys": "^0.2.0"
             }
         },
         "proxy-addr": {
@@ -10510,7 +10523,7 @@
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
             "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.9.1"
             }
         },
@@ -10518,6 +10531,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
             "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
             "version": "1.8.0",
@@ -10530,12 +10548,12 @@
             "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.9",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.5",
-                "randombytes": "2.1.0",
-                "safe-buffer": "5.1.2"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
             },
             "dependencies": {
                 "bn.js": {
@@ -10550,9 +10568,10 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+            "dev": true,
             "requires": {
-                "end-of-stream": "1.4.4",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -10560,9 +10579,9 @@
             "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "requires": {
-                "duplexify": "3.7.1",
-                "inherits": "2.0.4",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             },
             "dependencies": {
                 "pump": {
@@ -10570,8 +10589,8 @@
                     "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
                     "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
                     "requires": {
-                        "end-of-stream": "1.4.4",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                     }
                 }
             }
@@ -10609,7 +10628,7 @@
             "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
             "dev": true,
             "requires": {
-                "performance-now": "2.1.0"
+                "performance-now": "^2.1.0"
             }
         },
         "railroad-diagrams": {
@@ -10630,7 +10649,7 @@
             "dev": true,
             "requires": {
                 "discontinuous-range": "1.0.0",
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "randombytes": {
@@ -10639,7 +10658,7 @@
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -10648,8 +10667,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.1.0",
-                "safe-buffer": "5.1.2"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -10679,9 +10698,9 @@
             "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
             "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "prop-types": "15.7.2"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
             }
         },
         "react-dom": {
@@ -10689,10 +10708,10 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
             "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1",
-                "prop-types": "15.7.2",
-                "scheduler": "0.19.1"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "scheduler": "^0.19.1"
             }
         },
         "react-is": {
@@ -10705,11 +10724,11 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
             "integrity": "sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==",
             "requires": {
-                "@babel/runtime": "7.10.4",
-                "hoist-non-react-statics": "3.3.2",
-                "loose-envify": "1.4.0",
-                "prop-types": "15.7.2",
-                "react-is": "16.13.1"
+                "@babel/runtime": "^7.5.5",
+                "hoist-non-react-statics": "^3.3.0",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.9.0"
             }
         },
         "react-svg-core": {
@@ -10717,13 +10736,13 @@
             "resolved": "https://registry.npmjs.org/react-svg-core/-/react-svg-core-3.0.3.tgz",
             "integrity": "sha512-Ws3eM3xCAwcaYeqm4Ajcz3zxBYNI6BeTWWhFR0cpOT+pWuVtozgHYK9xUM0S/ilapZgYMQDe49XgOxpvooFq4w==",
             "requires": {
-                "@babel/core": "7.10.4",
-                "@babel/plugin-syntax-jsx": "7.10.4",
-                "@babel/preset-react": "7.10.4",
-                "babel-plugin-react-svg": "3.0.3",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.isplainobject": "4.0.6",
-                "svgo": "1.3.2"
+                "@babel/core": "^7.4.5",
+                "@babel/plugin-syntax-jsx": "^7.2.0",
+                "@babel/preset-react": "^7.0.0",
+                "babel-plugin-react-svg": "^3.0.3",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.isplainobject": "^4.0.6",
+                "svgo": "^1.2.2"
             }
         },
         "react-svg-loader": {
@@ -10731,8 +10750,8 @@
             "resolved": "https://registry.npmjs.org/react-svg-loader/-/react-svg-loader-3.0.3.tgz",
             "integrity": "sha512-V1KnIUtvWVvc4xCig34n+f+/74ylMMugB2FbuAF/yq+QRi+WLi2hUYp9Ze3VylhA1D7ZgRygBh3Ojj8S3TPhJA==",
             "requires": {
-                "loader-utils": "1.4.0",
-                "react-svg-core": "3.0.3"
+                "loader-utils": "^1.2.3",
+                "react-svg-core": "^3.0.3"
             }
         },
         "react-test-renderer": {
@@ -10741,10 +10760,10 @@
             "integrity": "sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prop-types": "15.7.2",
-                "react-is": "16.13.1",
-                "scheduler": "0.19.1"
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.8.6",
+                "scheduler": "^0.19.1"
             }
         },
         "read-pkg": {
@@ -10753,9 +10772,9 @@
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
             "dev": true,
             "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.5.0",
-                "path-type": "2.0.0"
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
             }
         },
         "read-pkg-up": {
@@ -10764,8 +10783,8 @@
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -10774,7 +10793,7 @@
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
-                        "locate-path": "2.0.0"
+                        "locate-path": "^2.0.0"
                     }
                 },
                 "locate-path": {
@@ -10783,8 +10802,8 @@
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "p-limit": {
@@ -10793,7 +10812,7 @@
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
-                        "p-try": "1.0.0"
+                        "p-try": "^1.0.0"
                     }
                 },
                 "p-locate": {
@@ -10802,7 +10821,7 @@
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
-                        "p-limit": "1.3.0"
+                        "p-limit": "^1.1.0"
                     }
                 },
                 "p-try": {
@@ -10818,13 +10837,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.4",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.1",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -10834,7 +10853,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "picomatch": "2.2.2"
+                "picomatch": "^2.2.1"
             }
         },
         "rechoir": {
@@ -10843,7 +10862,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.17.0"
+                "resolve": "^1.1.6"
             }
         },
         "redux": {
@@ -10851,8 +10870,8 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
             "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
             "requires": {
-                "loose-envify": "1.4.0",
-                "symbol-observable": "1.2.0"
+                "loose-envify": "^1.4.0",
+                "symbol-observable": "^1.2.0"
             }
         },
         "redux-devtools-extension": {
@@ -10882,8 +10901,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexp.prototype.flags": {
@@ -10892,8 +10911,8 @@
             "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
             }
         },
         "regexpp": {
@@ -10926,26 +10945,26 @@
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.10.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.8",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.3",
-                "har-validator": "5.1.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.27",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.5.0",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.4.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "form-data": {
@@ -10954,9 +10973,9 @@
                     "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.8",
-                        "mime-types": "2.1.27"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "qs": {
@@ -10978,10 +10997,10 @@
             "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
             "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
             "requires": {
-                "bluebird": "3.7.2",
+                "bluebird": "^3.5.0",
                 "request-promise-core": "1.1.3",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.5.0"
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "request-promise-core": {
@@ -10989,7 +11008,7 @@
             "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
             "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
             "requires": {
-                "lodash": "4.17.15"
+                "lodash": "^4.17.15"
             }
         },
         "request-promise-native": {
@@ -10999,8 +11018,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.3",
-                "stealthy-require": "1.1.1",
-                "tough-cookie": "2.5.0"
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {
@@ -11018,7 +11037,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-cwd": {
@@ -11027,7 +11046,7 @@
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
             "requires": {
-                "resolve-from": "5.0.0"
+                "resolve-from": "^5.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -11044,8 +11063,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             },
             "dependencies": {
                 "global-modules": {
@@ -11054,9 +11073,9 @@
                     "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
                     "dev": true,
                     "requires": {
-                        "global-prefix": "1.0.2",
-                        "is-windows": "1.0.2",
-                        "resolve-dir": "1.0.1"
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
                     }
                 }
             }
@@ -11079,8 +11098,8 @@
             "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
             "dev": true,
             "requires": {
-                "onetime": "5.1.0",
-                "signal-exit": "3.0.3"
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -11094,7 +11113,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "requires": {
-                "glob": "7.1.6"
+                "glob": "^7.1.3"
             }
         },
         "ripemd160": {
@@ -11103,8 +11122,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "3.1.0",
-                "inherits": "2.0.4"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "rst-selector-parser": {
@@ -11113,8 +11132,8 @@
             "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
             "dev": true,
             "requires": {
-                "lodash.flattendeep": "4.4.0",
-                "nearley": "2.19.4"
+                "lodash.flattendeep": "^4.4.0",
+                "nearley": "^2.7.10"
             }
         },
         "rsvp": {
@@ -11128,7 +11147,7 @@
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "rxjs": {
@@ -11137,7 +11156,7 @@
             "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
             "dev": true,
             "requires": {
-                "tslib": "1.13.0"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -11151,7 +11170,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -11165,15 +11184,15 @@
             "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "dev": true,
             "requires": {
-                "@cnakazawa/watch": "1.0.4",
-                "anymatch": "2.0.0",
-                "capture-exit": "2.0.0",
-                "exec-sh": "0.3.4",
-                "execa": "1.0.0",
-                "fb-watchman": "2.0.1",
-                "micromatch": "3.1.10",
-                "minimist": "1.2.5",
-                "walker": "1.0.7"
+                "@cnakazawa/watch": "^1.0.3",
+                "anymatch": "^2.0.0",
+                "capture-exit": "^2.0.0",
+                "exec-sh": "^0.3.2",
+                "execa": "^1.0.0",
+                "fb-watchman": "^2.0.0",
+                "micromatch": "^3.1.4",
+                "minimist": "^1.1.1",
+                "walker": "~1.0.5"
             },
             "dependencies": {
                 "anymatch": {
@@ -11182,8 +11201,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "braces": {
@@ -11192,16 +11211,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -11210,7 +11229,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -11221,10 +11240,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -11233,7 +11252,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -11244,7 +11263,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -11253,7 +11272,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -11264,19 +11283,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.3",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "normalize-path": {
@@ -11285,7 +11304,7 @@
                     "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
                     "dev": true,
                     "requires": {
-                        "remove-trailing-separator": "1.1.0"
+                        "remove-trailing-separator": "^1.0.1"
                     }
                 },
                 "to-regex-range": {
@@ -11294,8 +11313,8 @@
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
                     "requires": {
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -11311,7 +11330,7 @@
             "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
             "dev": true,
             "requires": {
-                "xmlchars": "2.2.0"
+                "xmlchars": "^2.2.0"
             }
         },
         "scheduler": {
@@ -11319,18 +11338,19 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
             "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
             "requires": {
-                "loose-envify": "1.4.0",
-                "object-assign": "4.1.1"
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "schema-utils": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
             "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+            "dev": true,
             "requires": {
-                "ajv": "6.12.2",
-                "ajv-errors": "1.0.1",
-                "ajv-keywords": "3.5.0"
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
             }
         },
         "script-loader": {
@@ -11339,7 +11359,7 @@
             "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
             "dev": true,
             "requires": {
-                "raw-loader": "0.5.1"
+                "raw-loader": "~0.5.1"
             }
         },
         "semver": {
@@ -11365,18 +11385,18 @@
             "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.7.2",
+                "http-errors": "~1.7.2",
                 "mime": "1.6.0",
                 "ms": "2.1.1",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.1",
-                "statuses": "1.5.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -11411,9 +11431,9 @@
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
             "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.3",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
                 "send": "0.17.1"
             }
         },
@@ -11428,10 +11448,10 @@
             "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -11440,7 +11460,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -11462,8 +11482,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shebang-command": {
@@ -11472,7 +11492,7 @@
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "requires": {
-                "shebang-regex": "3.0.0"
+                "shebang-regex": "^3.0.0"
             }
         },
         "shebang-regex": {
@@ -11487,9 +11507,9 @@
             "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
             "dev": true,
             "requires": {
-                "glob": "7.1.6",
-                "interpret": "1.4.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "shellwords": {
@@ -11505,8 +11525,8 @@
             "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
             "dev": true,
             "requires": {
-                "es-abstract": "1.17.6",
-                "object-inspect": "1.8.0"
+                "es-abstract": "^1.17.0-next.1",
+                "object-inspect": "^1.7.0"
             }
         },
         "signal-exit": {
@@ -11533,9 +11553,9 @@
             "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "astral-regex": "1.0.0",
-                "is-fullwidth-code-point": "2.0.0"
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -11552,14 +11572,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.3",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -11577,7 +11597,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -11586,7 +11606,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "ms": {
@@ -11609,9 +11629,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -11620,7 +11640,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -11629,7 +11649,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -11638,7 +11658,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.3"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -11647,9 +11667,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.3"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -11660,7 +11680,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -11669,7 +11689,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -11690,11 +11710,11 @@
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "dev": true,
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -11703,8 +11723,8 @@
             "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
@@ -11719,8 +11739,8 @@
             "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.1",
-                "spdx-license-ids": "3.0.5"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -11735,8 +11755,8 @@
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.3.0",
-                "spdx-license-ids": "3.0.5"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -11751,7 +11771,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -11765,23 +11785,24 @@
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "ssri": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
             "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+            "dev": true,
             "requires": {
-                "figgy-pudding": "3.5.2"
+                "figgy-pudding": "^3.5.1"
             }
         },
         "stable": {
@@ -11795,7 +11816,7 @@
             "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "2.0.0"
+                "escape-string-regexp": "^2.0.0"
             },
             "dependencies": {
                 "escape-string-regexp": {
@@ -11812,8 +11833,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -11822,7 +11843,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -11843,8 +11864,8 @@
             "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-each": {
@@ -11852,8 +11873,8 @@
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "requires": {
-                "end-of-stream": "1.4.4",
-                "stream-shift": "1.0.1"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "stream-http": {
@@ -11862,11 +11883,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.4",
-                "readable-stream": "2.3.7",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.2"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "stream-shift": {
@@ -11886,8 +11907,8 @@
             "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
             "dev": true,
             "requires": {
-                "char-regex": "1.0.2",
-                "strip-ansi": "6.0.0"
+                "char-regex": "^1.0.2",
+                "strip-ansi": "^6.0.0"
             }
         },
         "string-width": {
@@ -11895,9 +11916,9 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
             "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
             "requires": {
-                "emoji-regex": "8.0.0",
-                "is-fullwidth-code-point": "3.0.0",
-                "strip-ansi": "6.0.0"
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.0"
             }
         },
         "string.prototype.matchall": {
@@ -11906,12 +11927,12 @@
             "integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "has-symbols": "1.0.1",
-                "internal-slot": "1.0.2",
-                "regexp.prototype.flags": "1.3.0",
-                "side-channel": "1.0.2"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0",
+                "has-symbols": "^1.0.1",
+                "internal-slot": "^1.0.2",
+                "regexp.prototype.flags": "^1.3.0",
+                "side-channel": "^1.0.2"
             }
         },
         "string.prototype.trim": {
@@ -11920,9 +11941,9 @@
             "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1"
             }
         },
         "string.prototype.trimend": {
@@ -11930,8 +11951,8 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
             "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "string.prototype.trimstart": {
@@ -11939,8 +11960,8 @@
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
             "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "string_decoder": {
@@ -11948,7 +11969,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringify-object": {
@@ -11957,9 +11978,9 @@
             "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
             "dev": true,
             "requires": {
-                "get-own-enumerable-property-symbols": "3.0.2",
-                "is-obj": "1.0.1",
-                "is-regexp": "1.0.0"
+                "get-own-enumerable-property-symbols": "^3.0.0",
+                "is-obj": "^1.0.1",
+                "is-regexp": "^1.0.0"
             }
         },
         "strip-ansi": {
@@ -11967,7 +11988,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
             "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
             "requires": {
-                "ansi-regex": "5.0.0"
+                "ansi-regex": "^5.0.0"
             }
         },
         "strip-bom": {
@@ -12000,8 +12021,8 @@
             "integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
             "dev": true,
             "requires": {
-                "loader-utils": "2.0.0",
-                "schema-utils": "2.7.0"
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^2.6.6"
             },
             "dependencies": {
                 "json5": {
@@ -12010,7 +12031,7 @@
                     "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.5"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "loader-utils": {
@@ -12019,9 +12040,9 @@
                     "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
                     "dev": true,
                     "requires": {
-                        "big.js": "5.2.2",
-                        "emojis-list": "3.0.0",
-                        "json5": "2.1.3"
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
                     }
                 },
                 "schema-utils": {
@@ -12030,9 +12051,9 @@
                     "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
                     "dev": true,
                     "requires": {
-                        "@types/json-schema": "7.0.5",
-                        "ajv": "6.12.2",
-                        "ajv-keywords": "3.5.0"
+                        "@types/json-schema": "^7.0.4",
+                        "ajv": "^6.12.2",
+                        "ajv-keywords": "^3.4.1"
                     }
                 }
             }
@@ -12042,7 +12063,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "supports-hyperlinks": {
@@ -12051,8 +12072,8 @@
             "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
             "dev": true,
             "requires": {
-                "has-flag": "4.0.0",
-                "supports-color": "7.1.0"
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
             },
             "dependencies": {
                 "has-flag": {
@@ -12067,7 +12088,7 @@
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "4.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -12077,19 +12098,19 @@
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
             "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
             "requires": {
-                "chalk": "2.4.2",
-                "coa": "2.0.2",
-                "css-select": "2.1.0",
-                "css-select-base-adapter": "0.1.1",
+                "chalk": "^2.4.1",
+                "coa": "^2.0.2",
+                "css-select": "^2.0.0",
+                "css-select-base-adapter": "^0.1.1",
                 "css-tree": "1.0.0-alpha.37",
-                "csso": "4.0.3",
-                "js-yaml": "3.14.0",
-                "mkdirp": "0.5.5",
-                "object.values": "1.1.1",
-                "sax": "1.2.4",
-                "stable": "0.1.8",
-                "unquote": "1.1.1",
-                "util.promisify": "1.0.1"
+                "csso": "^4.0.2",
+                "js-yaml": "^3.13.1",
+                "mkdirp": "~0.5.1",
+                "object.values": "^1.1.0",
+                "sax": "~1.2.4",
+                "stable": "^0.1.8",
+                "unquote": "~1.1.1",
+                "util.promisify": "~1.0.0"
             }
         },
         "symbol-observable": {
@@ -12109,10 +12130,10 @@
             "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
             "dev": true,
             "requires": {
-                "ajv": "6.12.2",
-                "lodash": "4.17.15",
-                "slice-ansi": "2.1.0",
-                "string-width": "3.1.0"
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -12139,9 +12160,9 @@
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "7.0.3",
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "5.2.0"
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -12150,7 +12171,7 @@
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "4.1.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -12167,8 +12188,8 @@
             "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "4.3.1",
-                "supports-hyperlinks": "2.1.0"
+                "ansi-escapes": "^4.2.1",
+                "supports-hyperlinks": "^2.0.0"
             }
         },
         "terser": {
@@ -12177,9 +12198,9 @@
             "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
             "dev": true,
             "requires": {
-                "commander": "2.20.3",
-                "source-map": "0.6.1",
-                "source-map-support": "0.5.19"
+                "commander": "^2.20.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.12"
             }
         },
         "terser-webpack-plugin": {
@@ -12188,15 +12209,15 @@
             "integrity": "sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==",
             "dev": true,
             "requires": {
-                "cacache": "12.0.4",
-                "find-cache-dir": "2.1.0",
-                "is-wsl": "1.1.0",
-                "schema-utils": "1.0.0",
-                "serialize-javascript": "3.1.0",
-                "source-map": "0.6.1",
-                "terser": "4.8.0",
-                "webpack-sources": "1.4.3",
-                "worker-farm": "1.7.0"
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^3.1.0",
+                "source-map": "^0.6.1",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
             },
             "dependencies": {
                 "serialize-javascript": {
@@ -12205,7 +12226,7 @@
                     "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
                     "dev": true,
                     "requires": {
-                        "randombytes": "2.1.0"
+                        "randombytes": "^2.1.0"
                     }
                 }
             }
@@ -12216,9 +12237,9 @@
             "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
             "dev": true,
             "requires": {
-                "@istanbuljs/schema": "0.1.2",
-                "glob": "7.1.6",
-                "minimatch": "3.0.4"
+                "@istanbuljs/schema": "^0.1.2",
+                "glob": "^7.1.4",
+                "minimatch": "^3.0.4"
             }
         },
         "text-table": {
@@ -12232,7 +12253,7 @@
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "requires": {
-                "any-promise": "1.3.0"
+                "any-promise": "^1.0.0"
             }
         },
         "thenify-all": {
@@ -12240,7 +12261,7 @@
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
             "requires": {
-                "thenify": "3.3.1"
+                "thenify": ">= 3.1.0 < 4"
             }
         },
         "throat": {
@@ -12260,8 +12281,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "requires": {
-                "readable-stream": "2.3.7",
-                "xtend": "4.0.2"
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "timers-browserify": {
@@ -12270,7 +12291,7 @@
             "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "tmpl": {
@@ -12296,7 +12317,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -12305,7 +12326,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -12316,10 +12337,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -12328,7 +12349,7 @@
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "requires": {
-                "is-number": "7.0.0"
+                "is-number": "^7.0.0"
             }
         },
         "toidentifier": {
@@ -12341,8 +12362,8 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "requires": {
-                "psl": "1.8.0",
-                "punycode": "2.1.1"
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tr46": {
@@ -12351,7 +12372,7 @@
             "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.1"
             }
         },
         "tryer": {
@@ -12365,16 +12386,16 @@
             "integrity": "sha512-Lk/357quLg5jJFyBQLnSbhycnB3FPe+e9i7ahxokyXxAYoB0q1pPmqxxRPYr4smJic1Rjcf7MXDBhZWgxlli0A==",
             "dev": true,
             "requires": {
-                "bs-logger": "0.2.6",
-                "buffer-from": "1.1.1",
-                "fast-json-stable-stringify": "2.1.0",
-                "json5": "2.1.3",
-                "lodash.memoize": "4.1.2",
-                "make-error": "1.3.6",
-                "micromatch": "4.0.2",
-                "mkdirp": "1.0.4",
-                "semver": "7.3.2",
-                "yargs-parser": "18.1.3"
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "json5": "2.x",
+                "lodash.memoize": "4.x",
+                "make-error": "1.x",
+                "micromatch": "4.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "18.x"
             },
             "dependencies": {
                 "json5": {
@@ -12383,7 +12404,7 @@
                     "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.5"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "mkdirp": {
@@ -12406,11 +12427,11 @@
             "integrity": "sha512-zXypEIT6k3oTc+OZNx/cqElrsbBtYqDknf48OZos0NQ3RTt045fBIU8RRSu+suObBzYB355aIPGOe/3kj9h7Ig==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.2",
-                "enhanced-resolve": "4.2.0",
-                "loader-utils": "1.4.0",
-                "micromatch": "4.0.2",
-                "semver": "6.3.0"
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^4.0.0",
+                "semver": "^6.0.0"
             },
             "dependencies": {
                 "semver": {
@@ -12427,10 +12448,10 @@
             "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
             "dev": true,
             "requires": {
-                "@types/json5": "0.0.29",
-                "json5": "1.0.1",
-                "minimist": "1.2.5",
-                "strip-bom": "3.0.0"
+                "@types/json5": "^0.0.29",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "tslib": {
@@ -12445,7 +12466,7 @@
             "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
             "dev": true,
             "requires": {
-                "tslib": "1.13.0"
+                "tslib": "^1.8.1"
             }
         },
         "tty-browserify": {
@@ -12460,7 +12481,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -12475,7 +12496,7 @@
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.2.1"
+                "prelude-ls": "^1.2.1"
             }
         },
         "type-detect": {
@@ -12496,7 +12517,7 @@
             "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.27"
+                "mime-types": "~2.1.24"
             }
         },
         "typedarray": {
@@ -12510,7 +12531,7 @@
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
             "dev": true,
             "requires": {
-                "is-typedarray": "1.0.0"
+                "is-typedarray": "^1.0.0"
             }
         },
         "typedoc": {
@@ -12519,16 +12540,16 @@
             "integrity": "sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==",
             "dev": true,
             "requires": {
-                "fs-extra": "8.1.0",
-                "handlebars": "4.7.6",
-                "highlight.js": "10.1.1",
-                "lodash": "4.17.15",
-                "lunr": "2.3.8",
+                "fs-extra": "^8.1.0",
+                "handlebars": "^4.7.6",
+                "highlight.js": "^10.0.0",
+                "lodash": "^4.17.15",
+                "lunr": "^2.3.8",
                 "marked": "1.0.0",
-                "minimatch": "3.0.4",
-                "progress": "2.0.3",
-                "shelljs": "0.8.4",
-                "typedoc-default-themes": "0.10.2"
+                "minimatch": "^3.0.0",
+                "progress": "^2.0.3",
+                "shelljs": "^0.8.4",
+                "typedoc-default-themes": "^0.10.2"
             },
             "dependencies": {
                 "fs-extra": {
@@ -12537,9 +12558,9 @@
                     "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.4",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.2"
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "jsonfile": {
@@ -12548,7 +12569,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.2.4"
+                        "graceful-fs": "^4.1.6"
                     }
                 }
             }
@@ -12559,7 +12580,7 @@
             "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
             "dev": true,
             "requires": {
-                "lunr": "2.3.8"
+                "lunr": "^2.3.8"
             }
         },
         "typescript": {
@@ -12567,25 +12588,190 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
             "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
         },
+        "uglify-es": {
+            "version": "3.3.9",
+            "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+            "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+            "requires": {
+                "commander": "~2.13.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.13.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+                    "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+                }
+            }
+        },
         "uglify-js": {
             "version": "3.10.0",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-            "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA=="
+            "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+            "dev": true,
+            "optional": true
         },
         "uglifyjs-webpack-plugin": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz",
-            "integrity": "sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+            "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
             "requires": {
-                "cacache": "12.0.4",
-                "find-cache-dir": "2.1.0",
-                "is-wsl": "1.1.0",
-                "schema-utils": "1.0.0",
-                "serialize-javascript": "1.9.1",
-                "source-map": "0.6.1",
-                "uglify-js": "3.10.0",
-                "webpack-sources": "1.4.3",
-                "worker-farm": "1.7.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.5",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
+            },
+            "dependencies": {
+                "cacache": {
+                    "version": "10.0.4",
+                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+                    "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+                    "requires": {
+                        "bluebird": "^3.5.1",
+                        "chownr": "^1.0.1",
+                        "glob": "^7.1.2",
+                        "graceful-fs": "^4.1.11",
+                        "lru-cache": "^4.1.1",
+                        "mississippi": "^2.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "ssri": "^5.2.4",
+                        "unique-filename": "^1.1.0",
+                        "y18n": "^4.0.0"
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+                    "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^2.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+                    "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+                    "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "mississippi": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+                    "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+                    "requires": {
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^2.0.1",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+                },
+                "pkg-dir": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+                    "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+                    "requires": {
+                        "find-up": "^2.1.0"
+                    }
+                },
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "schema-utils": {
+                    "version": "0.4.7",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+                    "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "ssri": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+                    "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+                    "requires": {
+                        "safe-buffer": "^5.1.1"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+                }
             }
         },
         "union-value": {
@@ -12594,10 +12780,10 @@
             "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "2.0.1"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
             }
         },
         "uniq": {
@@ -12611,7 +12797,7 @@
             "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
             "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
             "requires": {
-                "unique-slug": "2.0.2"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -12619,7 +12805,7 @@
             "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
             "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "universalify": {
@@ -12644,8 +12830,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -12654,9 +12840,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -12690,7 +12876,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             }
         },
         "urix": {
@@ -12750,10 +12936,10 @@
             "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
             "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
             "requires": {
-                "define-properties": "1.1.3",
-                "es-abstract": "1.17.6",
-                "has-symbols": "1.0.1",
-                "object.getownpropertydescriptors": "2.1.0"
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.2",
+                "has-symbols": "^1.0.1",
+                "object.getownpropertydescriptors": "^2.1.0"
             }
         },
         "utils-merge": {
@@ -12780,9 +12966,9 @@
             "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "2.0.3",
-                "convert-source-map": "1.7.0",
-                "source-map": "0.7.3"
+                "@types/istanbul-lib-coverage": "^2.0.1",
+                "convert-source-map": "^1.6.0",
+                "source-map": "^0.7.3"
             },
             "dependencies": {
                 "source-map": {
@@ -12799,8 +12985,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.1.1",
-                "spdx-expression-parse": "3.0.1"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vary": {
@@ -12814,9 +13000,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vm-browserify": {
@@ -12831,7 +13017,7 @@
             "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "1.0.0"
+                "browser-process-hrtime": "^1.0.0"
             }
         },
         "w3c-xmlserializer": {
@@ -12840,7 +13026,7 @@
             "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
             "dev": true,
             "requires": {
-                "xml-name-validator": "3.0.0"
+                "xml-name-validator": "^3.0.0"
             }
         },
         "walker": {
@@ -12849,7 +13035,7 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dev": true,
             "requires": {
-                "makeerror": "1.0.11"
+                "makeerror": "1.0.x"
             }
         },
         "watchpack": {
@@ -12858,10 +13044,10 @@
             "integrity": "sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==",
             "dev": true,
             "requires": {
-                "chokidar": "3.4.0",
-                "graceful-fs": "4.2.4",
-                "neo-async": "2.6.1",
-                "watchpack-chokidar2": "2.0.0"
+                "chokidar": "^3.4.0",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0",
+                "watchpack-chokidar2": "^2.0.0"
             }
         },
         "watchpack-chokidar2": {
@@ -12871,7 +13057,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "chokidar": "2.1.8"
+                "chokidar": "^2.1.8"
             },
             "dependencies": {
                 "anymatch": {
@@ -12881,8 +13067,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     },
                     "dependencies": {
                         "normalize-path": {
@@ -12892,7 +13078,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "remove-trailing-separator": "1.1.0"
+                                "remove-trailing-separator": "^1.0.1"
                             }
                         }
                     }
@@ -12910,16 +13096,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -12928,7 +13114,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -12940,18 +13126,18 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.3",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.13",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.4",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.1",
-                        "normalize-path": "3.0.0",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.2.1",
-                        "upath": "1.2.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
                     }
                 },
                 "fill-range": {
@@ -12960,10 +13146,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -12972,7 +13158,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -12991,8 +13177,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -13002,7 +13188,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -13014,7 +13200,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "binary-extensions": "1.13.1"
+                        "binary-extensions": "^1.0.0"
                     }
                 },
                 "is-number": {
@@ -13023,7 +13209,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13032,7 +13218,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -13043,19 +13229,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.3",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "readdirp": {
@@ -13065,9 +13251,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "graceful-fs": "4.2.4",
-                        "micromatch": "3.1.10",
-                        "readable-stream": "2.3.7"
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "to-regex-range": {
@@ -13076,8 +13262,8 @@
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
                     "requires": {
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -13098,25 +13284,25 @@
                 "@webassemblyjs/helper-module-context": "1.9.0",
                 "@webassemblyjs/wasm-edit": "1.9.0",
                 "@webassemblyjs/wasm-parser": "1.9.0",
-                "acorn": "6.4.1",
-                "ajv": "6.12.2",
-                "ajv-keywords": "3.5.0",
-                "chrome-trace-event": "1.0.2",
-                "enhanced-resolve": "4.2.0",
-                "eslint-scope": "4.0.3",
-                "json-parse-better-errors": "1.0.2",
-                "loader-runner": "2.4.0",
-                "loader-utils": "1.4.0",
-                "memory-fs": "0.4.1",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.5",
-                "neo-async": "2.6.1",
-                "node-libs-browser": "2.2.1",
-                "schema-utils": "1.0.0",
-                "tapable": "1.1.3",
-                "terser-webpack-plugin": "1.4.4",
-                "watchpack": "1.7.2",
-                "webpack-sources": "1.4.3"
+                "acorn": "^6.4.1",
+                "ajv": "^6.10.2",
+                "ajv-keywords": "^3.4.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^4.1.0",
+                "eslint-scope": "^4.0.3",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^2.4.0",
+                "loader-utils": "^1.2.3",
+                "memory-fs": "^0.4.1",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.3",
+                "neo-async": "^2.6.1",
+                "node-libs-browser": "^2.2.1",
+                "schema-utils": "^1.0.0",
+                "tapable": "^1.1.3",
+                "terser-webpack-plugin": "^1.4.3",
+                "watchpack": "^1.6.1",
+                "webpack-sources": "^1.4.1"
             },
             "dependencies": {
                 "acorn": {
@@ -13131,16 +13317,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -13149,7 +13335,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -13160,8 +13346,8 @@
                     "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
                     "dev": true,
                     "requires": {
-                        "esrecurse": "4.2.1",
-                        "estraverse": "4.3.0"
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
                     }
                 },
                 "fill-range": {
@@ -13170,10 +13356,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -13182,7 +13368,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -13193,7 +13379,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13202,7 +13388,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -13213,8 +13399,8 @@
                     "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
                     "dev": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "readable-stream": "2.3.7"
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "micromatch": {
@@ -13223,19 +13409,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.3",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "to-regex-range": {
@@ -13244,8 +13430,8 @@
                     "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
                     "dev": true,
                     "requires": {
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -13255,19 +13441,19 @@
             "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.8.0.tgz",
             "integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
             "requires": {
-                "acorn": "7.3.1",
-                "acorn-walk": "7.2.0",
-                "bfj": "6.1.2",
-                "chalk": "2.4.2",
-                "commander": "2.20.3",
-                "ejs": "2.7.4",
-                "express": "4.17.1",
-                "filesize": "3.6.1",
-                "gzip-size": "5.1.1",
-                "lodash": "4.17.15",
-                "mkdirp": "0.5.5",
-                "opener": "1.5.1",
-                "ws": "6.2.1"
+                "acorn": "^7.1.1",
+                "acorn-walk": "^7.1.1",
+                "bfj": "^6.1.1",
+                "chalk": "^2.4.1",
+                "commander": "^2.18.0",
+                "ejs": "^2.6.1",
+                "express": "^4.16.3",
+                "filesize": "^3.6.1",
+                "gzip-size": "^5.0.0",
+                "lodash": "^4.17.15",
+                "mkdirp": "^0.5.1",
+                "opener": "^1.5.1",
+                "ws": "^6.0.0"
             }
         },
         "webpack-cli": {
@@ -13276,17 +13462,17 @@
             "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.2",
-                "cross-spawn": "6.0.5",
-                "enhanced-resolve": "4.2.0",
-                "findup-sync": "3.0.0",
-                "global-modules": "2.0.0",
-                "import-local": "2.0.0",
-                "interpret": "1.4.0",
-                "loader-utils": "1.4.0",
-                "supports-color": "6.1.0",
-                "v8-compile-cache": "2.1.1",
-                "yargs": "13.3.2"
+                "chalk": "^2.4.2",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.1.1",
+                "findup-sync": "^3.0.0",
+                "global-modules": "^2.0.0",
+                "import-local": "^2.0.0",
+                "interpret": "^1.4.0",
+                "loader-utils": "^1.4.0",
+                "supports-color": "^6.1.0",
+                "v8-compile-cache": "^2.1.1",
+                "yargs": "^13.3.2"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13301,9 +13487,9 @@
                     "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
                     "dev": true,
                     "requires": {
-                        "string-width": "3.1.0",
-                        "strip-ansi": "5.2.0",
-                        "wrap-ansi": "5.1.0"
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
                     }
                 },
                 "cross-spawn": {
@@ -13312,11 +13498,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.5",
-                        "path-key": "2.0.1",
-                        "semver": "5.7.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "emoji-regex": {
@@ -13331,8 +13517,8 @@
                     "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
                     "dev": true,
                     "requires": {
-                        "pkg-dir": "3.0.0",
-                        "resolve-cwd": "2.0.0"
+                        "pkg-dir": "^3.0.0",
+                        "resolve-cwd": "^2.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -13353,7 +13539,7 @@
                     "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
                     "dev": true,
                     "requires": {
-                        "resolve-from": "3.0.0"
+                        "resolve-from": "^3.0.0"
                     }
                 },
                 "resolve-from": {
@@ -13368,7 +13554,7 @@
                     "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                     "dev": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -13383,9 +13569,9 @@
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "7.0.3",
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "5.2.0"
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -13394,7 +13580,7 @@
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "4.1.0"
+                        "ansi-regex": "^4.1.0"
                     }
                 },
                 "supports-color": {
@@ -13403,7 +13589,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "which": {
@@ -13412,7 +13598,7 @@
                     "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "wrap-ansi": {
@@ -13421,9 +13607,9 @@
                     "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "string-width": "3.1.0",
-                        "strip-ansi": "5.2.0"
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
                     }
                 },
                 "yargs": {
@@ -13432,16 +13618,16 @@
                     "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "5.0.0",
-                        "find-up": "3.0.0",
-                        "get-caller-file": "2.0.5",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "2.0.0",
-                        "set-blocking": "2.0.0",
-                        "string-width": "3.1.0",
-                        "which-module": "2.0.0",
-                        "y18n": "4.0.0",
-                        "yargs-parser": "13.1.2"
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
                     }
                 },
                 "yargs-parser": {
@@ -13450,8 +13636,8 @@
                     "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "5.3.1",
-                        "decamelize": "1.2.0"
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -13461,8 +13647,8 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
             "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
             "requires": {
-                "source-list-map": "2.0.1",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             }
         },
         "whatwg-encoding": {
@@ -13486,9 +13672,9 @@
             "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "4.7.0",
-                "tr46": "2.0.2",
-                "webidl-conversions": "5.0.0"
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^2.0.2",
+                "webidl-conversions": "^5.0.0"
             },
             "dependencies": {
                 "webidl-conversions": {
@@ -13505,7 +13691,7 @@
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -13536,7 +13722,7 @@
             "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
             "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
             "requires": {
-                "errno": "0.1.7"
+                "errno": "~0.1.7"
             }
         },
         "worker-loader": {
@@ -13545,8 +13731,8 @@
             "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.4.0",
-                "schema-utils": "0.4.7"
+                "loader-utils": "^1.0.0",
+                "schema-utils": "^0.4.0"
             },
             "dependencies": {
                 "schema-utils": {
@@ -13555,8 +13741,8 @@
                     "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.12.2",
-                        "ajv-keywords": "3.5.0"
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
                     }
                 }
             }
@@ -13566,9 +13752,9 @@
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
             "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
             "requires": {
-                "ansi-styles": "4.2.1",
-                "string-width": "4.2.0",
-                "strip-ansi": "6.0.0"
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13576,8 +13762,8 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
                     "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
                     "requires": {
-                        "@types/color-name": "1.1.1",
-                        "color-convert": "2.0.1"
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
                     }
                 },
                 "color-convert": {
@@ -13585,7 +13771,7 @@
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "requires": {
-                        "color-name": "1.1.4"
+                        "color-name": "~1.1.4"
                     }
                 },
                 "color-name": {
@@ -13606,7 +13792,7 @@
             "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.5"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file": {
@@ -13614,8 +13800,8 @@
             "resolved": "https://registry.npmjs.org/write-file/-/write-file-1.0.0.tgz",
             "integrity": "sha1-Xi2sf9QMYxZIkfoN8GC4EEsFgGk=",
             "requires": {
-                "is-buffer": "1.1.6",
-                "mkdirp": "0.5.5"
+                "is-buffer": "^1.1.4",
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -13624,10 +13810,10 @@
             "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4",
-                "is-typedarray": "1.0.0",
-                "signal-exit": "3.0.3",
-                "typedarray-to-buffer": "3.1.5"
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
             }
         },
         "ws": {
@@ -13635,7 +13821,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
             "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
             "requires": {
-                "async-limiter": "1.0.1"
+                "async-limiter": "~1.0.0"
             }
         },
         "xml": {
@@ -13669,7 +13855,8 @@
         "yallist": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "yaml": {
             "version": "1.10.0",
@@ -13682,17 +13869,17 @@
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
             "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
             "requires": {
-                "cliui": "6.0.0",
-                "decamelize": "1.2.0",
-                "find-up": "4.1.0",
-                "get-caller-file": "2.0.5",
-                "require-directory": "2.1.1",
-                "require-main-filename": "2.0.0",
-                "set-blocking": "2.0.0",
-                "string-width": "4.2.0",
-                "which-module": "2.0.0",
-                "y18n": "4.0.0",
-                "yargs-parser": "18.1.3"
+                "cliui": "^6.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^4.1.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^4.2.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^18.1.2"
             },
             "dependencies": {
                 "find-up": {
@@ -13700,8 +13887,8 @@
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "requires": {
-                        "locate-path": "5.0.0",
-                        "path-exists": "4.0.0"
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
                     }
                 },
                 "locate-path": {
@@ -13709,7 +13896,7 @@
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "requires": {
-                        "p-locate": "4.1.0"
+                        "p-locate": "^4.1.0"
                     }
                 },
                 "p-locate": {
@@ -13717,7 +13904,7 @@
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "requires": {
-                        "p-limit": "2.3.0"
+                        "p-limit": "^2.2.0"
                     }
                 },
                 "path-exists": {
@@ -13732,8 +13919,8 @@
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
             "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
             "requires": {
-                "camelcase": "5.3.1",
-                "decamelize": "1.2.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "redux-thunk": "^2.3.0",
         "request-promise": "^4.2.5",
         "typescript": "^3.9.5",
-        "uglifyjs-webpack-plugin": "^2.2.0",
+        "uglifyjs-webpack-plugin": "^1.2.4",
         "webpack-bundle-analyzer": "^3.8.0",
         "write-file": "1.0.0",
         "yargs": "^15.3.1"

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const CleanWebpackPlugin = require('clean-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const WriteBundleFilePlugin = require('./WriteBundleFilePlugin');
@@ -9,10 +9,6 @@ const { PACKAGE_VERSION } = process.env;
 if (!PACKAGE_VERSION) {
     throw new Error('A version number must be supplied for a production build. eg. 1.0.0');
 }
-
-const pathsToClean = [
-    'dist',
-];
 
 const publicPaths = {
     DEVELOPMENT: 'https://manywho-ui-development.s3.eu-west-2.amazonaws.com/',
@@ -89,7 +85,7 @@ const config = {
         ],
     },
     plugins: [
-        new CleanWebpackPlugin(pathsToClean),
+        new CleanWebpackPlugin(),
         new UglifyJsPlugin({
             sourceMap: true,
         }),


### PR DESCRIPTION
…d to crash and updated version of uglify plugin seems to be incompatible with react-svg-loader so have downgraded the uglify version for now.

I think this relates to the older version of the uglify plugin having support for uglify-es (which supports es6+ input) whereas the newer plugin version has since deprecated this and supports only es5.

The error output by webpack:

`ERROR in js/flow-offline-70.js from UglifyJs
Unexpected token: operator «=» [./icons/Offline.svg:5,8][js/flow-offline-70.js:8804,9]`

To me this perhaps indicates that the react-svg-loader outputs es6 (although it's docs say otherwise).
When replacing the uglify plugin with the [terser](https://webpack.js.org/plugins/terser-webpack-plugin/) alternative which is recommended for when there is a requirement for supporting es6 input, everything builds fine.
However, I decided to just downgrade uglify for now and maybe just look at handling svg's using something better in the future.